### PR TITLE
Sets the name of reusable subsystems

### DIFF
--- a/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AprilTagSubsystem.java
@@ -100,6 +100,7 @@ public class AprilTagSubsystem extends SubsystemBase implements ShuffleboardProd
    * @param robotToCamera The transform from the robot to the camera.
    */
   public AprilTagSubsystem(String cameraName, Transform3d robotToCamera) {
+    setName(cameraName);
     this.camera = new PhotonCamera(cameraName);
     this.robotToCamera = robotToCamera;
     this.cameraToRobot = robotToCamera.inverse();
@@ -363,7 +364,7 @@ public class AprilTagSubsystem extends SubsystemBase implements ShuffleboardProd
             "http://photonvision.local:1190/stream.mjpg",
             HttpCameraKind.kMJPGStreamer);
 
-    ShuffleboardTab visionTab = Shuffleboard.getTab("April Tag");
+    ShuffleboardTab visionTab = Shuffleboard.getTab(getName());
     ShuffleboardLayout targetLayout =
         visionTab.getLayout("Target Info", BuiltInLayouts.kList).withPosition(0, 0).withSize(2, 5);
     targetLayout.add("ID Selection", aprilTagIdChooser).withWidget(BuiltInWidgets.kComboBoxChooser);

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -20,7 +20,6 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.parameters.ArmParameters;
 
 public class Arm extends SubsystemBase {
-  private final String name;
   private final TalonFX motor;
   private final DutyCycleEncoder absoluteEncoder;
 
@@ -37,7 +36,7 @@ public class Arm extends SubsystemBase {
 
   /** Creates a new Arm. */
   public Arm(ArmParameters parameters) {
-    name = parameters.toString();
+    setName(parameters.toString());
 
     feedForward = parameters.getArmFeedforward();
     profile = new TrapezoidProfile(parameters.getConstraints());
@@ -51,11 +50,6 @@ public class Arm extends SubsystemBase {
     configs.Inverted = InvertedValue.Clockwise_Positive;
     motor.getConfigurator().apply(configs);
     absoluteEncoder.setDutyCycleRange(1.0 / 1025.0, 1024.0 / 1025.0);
-  }
-
-  @Override
-  public String getName() {
-    return name;
   }
 
   /** Updates the sensor state. */

--- a/src/main/java/frc/robot/subsystems/CoralRoller.java
+++ b/src/main/java/frc/robot/subsystems/CoralRoller.java
@@ -128,7 +128,7 @@ public class CoralRoller extends SubsystemBase implements ShuffleboardProducer {
     if (!ENABLE_TAB.getValue()) {
       return;
     }
-    
+
     ShuffleboardTab rollerTab = Shuffleboard.getTab("Coral Roller");
     ShuffleboardLayout statusLayout =
         rollerTab.getLayout("Status", BuiltInLayouts.kList).withPosition(0, 0).withSize(2, 4);


### PR DESCRIPTION
Sets the name of reusable subsystems for command logging and Shuffleboard integration.

**NOTE:** The name of the camera is now used as the name of the AprilTagSubsystem.