### PR TITLE
Updates WPILib to 2025.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.2.1"
+    id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id "com.diffplug.spotless"  version "7.0.1"
 }
 

--- a/src/main/java/frc/robot/util/FieldUtils.java
+++ b/src/main/java/frc/robot/util/FieldUtils.java
@@ -18,8 +18,9 @@ import java.util.ArrayList;
 /** Helper methods related to the 2025 FRC ReefScape field. */
 public final class FieldUtils {
 
+  // TODO: Make field layout selectable.
   private static final AprilTagFieldLayout FIELD_LAYOUT =
-      AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+      AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeWelded);
 
   private static final ArrayList<Pose2d> redReefTags = new ArrayList<>(6);
   private static final ArrayList<Pose2d> blueReefTags = new ArrayList<>(6);


### PR DESCRIPTION
**NOTE:** There are now two AprilTag field layouts for REEFSCAPE. See [TeamUpdate12.pdf](https://firstfrc.blob.core.windows.net/frc2025/Manual/TeamUpdates/TeamUpdate12.pdf) for complete details but the summary is as follows:

> A variance has been discovered where the location of the PROCESSOR, other field elements, and 
corresponding AprilTags vary depending on which of the two field perimeter - Welded or AndyMark - is used. 
The Field Layout and Markings Diagram and the Field Drawings have been updated to include the AprilTag 
Coordinates when using an AndyMark perimeter. The WPILib AprilTag Map has also changed to reflect the 
updated AprilTag Coordinates and allow teams to choose a map based on which field type they will be using at 
their events.

*TODO:* Make the field layout selectable.
