### PR TITLE
Improves clarity of motor idle mode control

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -39,6 +39,7 @@ import frc.robot.commands.FlameCycle;
 import frc.robot.commands.LEDCommands;
 import frc.robot.commands.ManipulatorCommands;
 import frc.robot.subsystems.Subsystems;
+import frc.robot.util.MotorIdleMode;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -81,17 +82,18 @@ public class RobotContainer {
 
   public void disabledPeriodic() {
     if (coastModeTimer.hasElapsed(COAST_MODE_DELAY)) {
-      subsystems.setBrakeMode(false);
+      subsystems.setIdleMode(MotorIdleMode.COAST);
       coastModeTimer.stop();
+      coastModeTimer.reset();
     }
   }
 
   public void autonomousInit() {
-    subsystems.setBrakeMode(true);
+    subsystems.setIdleMode(MotorIdleMode.BRAKE);
   }
 
   public void teleopInit() {
-    subsystems.setBrakeMode(true);
+    subsystems.setIdleMode(MotorIdleMode.BRAKE);
   }
 
   private void initShuffleboard() {

--- a/src/main/java/frc/robot/parameters/AprilTagFieldParameters.java
+++ b/src/main/java/frc/robot/parameters/AprilTagFieldParameters.java
@@ -7,7 +7,6 @@
  
 package frc.robot.parameters;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 
 public enum AprilTagFieldParameters {

--- a/src/main/java/frc/robot/parameters/MotorParameters.java
+++ b/src/main/java/frc/robot/parameters/MotorParameters.java
@@ -13,6 +13,7 @@ import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import edu.wpi.first.math.system.plant.DCMotor;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.SparkAdapter;
 import frc.robot.util.TalonFXAdapter;
 import org.ejml.simple.UnsupportedOperation;
@@ -92,25 +93,32 @@ public enum MotorParameters {
     return this.motor.stallTorqueNewtonMeters;
   }
 
-  public MotorController getController(
-      int deviceID, boolean isInverted, boolean brakeMode, double metersPerRotation) {
+  /**
+   * Returns a new {@link MotorController} implementation for this motor type.
+   *
+   * @param deviceID The CAN device ID.
+   * @param isInverted Whether the motor should be inverted.
+   * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
+   * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
+   *     the output shaft.
+   * @return A new MotorController implementation.
+   */
+  public MotorController newController(
+      int deviceID, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
     switch (this) {
       case Falcon500:
       case KrakenX60:
-        return new TalonFXAdapter(new TalonFX(deviceID), isInverted, brakeMode, metersPerRotation);
+        return new TalonFXAdapter(new TalonFX(deviceID), isInverted, idleMode, metersPerRotation);
 
       case NeoV1_1:
       case NeoVortexMax:
       case Neo550:
         return new SparkAdapter(
-            new SparkMax(deviceID, MotorType.kBrushless), isInverted, brakeMode, metersPerRotation);
+            new SparkMax(deviceID, MotorType.kBrushless), isInverted, idleMode, metersPerRotation);
 
       case NeoVortexFlex:
         return new SparkAdapter(
-            new SparkFlex(deviceID, MotorType.kBrushless),
-            isInverted,
-            brakeMode,
-            metersPerRotation);
+            new SparkFlex(deviceID, MotorType.kBrushless), isInverted, idleMode, metersPerRotation);
 
       default:
         throw new UnsupportedOperation("Unknown Motor Type");

--- a/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
@@ -26,6 +26,7 @@ import edu.wpi.first.math.trajectory.constraint.SwerveDriveKinematicsConstraint;
 import edu.wpi.first.math.util.Units;
 import frc.robot.util.Gyro;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.NavXGyro;
 import frc.robot.util.Pigeon2Gyro;
 
@@ -482,10 +483,12 @@ public enum SwerveDriveParameters {
       case BackLeftDrive:
       case BackRightDrive:
         final double metersPerRotation = (getWheelDiameter() * Math.PI) / getDriveGearRatio();
-        return this.driveMotor.getController(motorID, false, true, metersPerRotation);
+        return this.driveMotor.newController(
+            motorID, false, MotorIdleMode.BRAKE, metersPerRotation);
 
       default:
-        return this.steeringMotor.getController(motorID, isSteeringInverted(), true, 1.0);
+        return this.steeringMotor.newController(
+            motorID, isSteeringInverted(), MotorIdleMode.BRAKE, 1.0);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/ActiveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ActiveSubsystem.java
@@ -7,11 +7,13 @@
  
 package frc.robot.subsystems;
 
+import frc.robot.util.MotorIdleMode;
+
 /** Interface representing an active subsystem. */
 public interface ActiveSubsystem {
   /** Disables the subsystem. */
   void disable();
 
-  /** Sets idle mode of motor(s) to either brake mode if true or coast mode if false. */
-  void setBrakeMode(boolean brakeMode);
+  /** Sets idle mode of motor(s) to either brake mode or coast mode. */
+  void setIdleMode(MotorIdleMode idleMode);
 }

--- a/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
@@ -12,6 +12,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.ForwardLimitValue;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.RobotConstants;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.MotorUtils;
 
 public class AlgaeGrabber extends SubsystemBase implements ActiveSubsystem {
@@ -48,8 +49,8 @@ public class AlgaeGrabber extends SubsystemBase implements ActiveSubsystem {
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    MotorUtils.setBrakeMode(motor, brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    MotorUtils.setIdleMode(motor, idleMode);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -35,6 +35,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.parameters.ArmParameters;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.MotorUtils;
 
 @RobotPreferencesLayout(groupName = "Arm", row = 1, column = 0, width = 1, height = 1)
@@ -152,8 +153,8 @@ public class Arm extends SubsystemBase implements ActiveSubsystem, ShuffleboardP
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    MotorUtils.setBrakeMode(motor, brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    MotorUtils.setIdleMode(motor, idleMode);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.TalonFXAdapter;
 
 @RobotPreferencesLayout(groupName = "Climber", row = 0, column = 6, width = 1, height = 3)
@@ -70,7 +71,7 @@ public class Climber extends SubsystemBase implements ShuffleboardProducer, Acti
       new TalonFXAdapter(
           new TalonFX(RobotConstants.CAN.TalonFX.CLIMBER_MAIN_MOTOR_ID, "rio"),
           false,
-          true,
+          MotorIdleMode.BRAKE,
           1); // filler value; motor encoder value is not used.
 
   private MotorController follower =
@@ -155,9 +156,9 @@ public class Climber extends SubsystemBase implements ShuffleboardProducer, Acti
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    mainMotor.setBrakeMode(brakeMode);
-    follower.setBrakeMode(brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    mainMotor.setIdleMode(idleMode);
+    follower.setIdleMode(idleMode);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/CoralRoller.java
+++ b/src/main/java/frc/robot/subsystems/CoralRoller.java
@@ -32,6 +32,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.parameters.MotorParameters;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.MotorUtils;
 
 @RobotPreferencesLayout(groupName = "CoralRoller", row = 2, column = 0, width = 1, height = 1)
@@ -108,8 +109,8 @@ public class CoralRoller extends SubsystemBase implements ActiveSubsystem, Shuff
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    MotorUtils.setBrakeMode(motor, brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    MotorUtils.setIdleMode(motor, idleMode);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -38,6 +38,7 @@ import frc.robot.Constants.RobotConstants;
 import frc.robot.commands.ElevatorCommands;
 import frc.robot.parameters.ElevatorLevel;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
 import java.util.Set;
@@ -99,7 +100,7 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
       new TalonFXAdapter(
           new TalonFX(RobotConstants.CAN.TalonFX.ELEVATOR_MAIN_MOTOR_ID, "rio"),
           false,
-          true,
+          MotorIdleMode.BRAKE,
           METERS_PER_REVOLUTION);
 
   private MotorController follower =
@@ -222,9 +223,9 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    mainMotor.setBrakeMode(brakeMode);
-    follower.setBrakeMode(brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    mainMotor.setIdleMode(idleMode);
+    follower.setIdleMode(idleMode);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Subsystems.java
+++ b/src/main/java/frc/robot/subsystems/Subsystems.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.robot.parameters.ArmParameters;
+import frc.robot.util.MotorIdleMode;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -159,10 +160,10 @@ public class Subsystems {
     }
   }
 
-  public void setBrakeMode(boolean brakeMode) {
+  public void setIdleMode(MotorIdleMode idleMode) {
     for (Subsystem subsystem : all) {
       if (subsystem instanceof ActiveSubsystem) {
-        ActiveSubsystem.class.cast(subsystem).setBrakeMode(brakeMode);
+        ActiveSubsystem.class.cast(subsystem).setIdleMode(idleMode);
       }
     }
   }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -56,6 +56,7 @@ import frc.robot.parameters.SwerveDriveParameters;
 import frc.robot.parameters.SwerveMotors;
 import frc.robot.util.Gyro;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.SwerveModuleVelocities;
 import frc.robot.util.SwerveModuleVoltages;
@@ -523,16 +524,16 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
     poseAngleLog.append(robotPose.getRotation().getDegrees());
   }
 
-  public void setBrakeMode(boolean brakeMode) {
-    frontLeftDriveMotor.setBrakeMode(brakeMode);
-    frontRightDriveMotor.setBrakeMode(brakeMode);
-    backLeftDriveMotor.setBrakeMode(brakeMode);
-    backRightDriveMotor.setBrakeMode(brakeMode);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    frontLeftDriveMotor.setIdleMode(idleMode);
+    frontRightDriveMotor.setIdleMode(idleMode);
+    backLeftDriveMotor.setIdleMode(idleMode);
+    backRightDriveMotor.setIdleMode(idleMode);
 
-    frontLeftSteeringMotor.setBrakeMode(brakeMode);
-    frontRightSteeringMotor.setBrakeMode(brakeMode);
-    backLeftSteeringMotor.setBrakeMode(brakeMode);
-    backRightSteeringMotor.setBrakeMode(brakeMode);
+    frontLeftSteeringMotor.setIdleMode(idleMode);
+    frontRightSteeringMotor.setIdleMode(idleMode);
+    backLeftSteeringMotor.setIdleMode(idleMode);
+    backRightSteeringMotor.setIdleMode(idleMode);
   }
 
   /** Adds a tab for swerve drive in Shuffleboard. */

--- a/src/main/java/frc/robot/util/MotorController.java
+++ b/src/main/java/frc/robot/util/MotorController.java
@@ -27,6 +27,6 @@ public interface MotorController extends edu.wpi.first.wpilibj.motorcontrol.Moto
   /** Returns the reverse limit switch. */
   LimitSwitch getReverseLimitSwitch();
 
-  /** Sets Brake Mode. */
-  void setBrakeMode(boolean brakeMode);
+  /** Sets the motor behavior when idle (i.e. brake or coast mode). */
+  void setIdleMode(MotorIdleMode idleMode);
 }

--- a/src/main/java/frc/robot/util/MotorIdleMode.java
+++ b/src/main/java/frc/robot/util/MotorIdleMode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
+ *
+ * Open Source Software; you can modify and/or share it under the terms of
+ * the license file in the root directory of this project.
+ */
+ 
+package frc.robot.util;
+
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+
+/** The motor controller behavior when idle. */
+public enum MotorIdleMode {
+  /**
+   * The motor controller effectively disconnects the motor circuit allowing it to spin down at its
+   * natural rate.
+   */
+  COAST,
+  /**
+   * The motor controller effectively short circuits the motor causing electrical energy to
+   * dissipate quickly and bring it to a quick stop.
+   */
+  BRAKE;
+
+  /** Returns the TalonFX equivalent of this idle mode. */
+  public NeutralModeValue forTalonFX() {
+    return this == COAST ? NeutralModeValue.Coast : NeutralModeValue.Brake;
+  }
+
+  /** Returns the SparkMax/SparkFlex equivalent of this idle mode. */
+  public IdleMode forSpark() {
+    return this == COAST ? IdleMode.kCoast : IdleMode.kBrake;
+  }
+}

--- a/src/main/java/frc/robot/util/MotorUtils.java
+++ b/src/main/java/frc/robot/util/MotorUtils.java
@@ -9,15 +9,14 @@ package frc.robot.util;
 
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.hardware.TalonFX;
-import com.ctre.phoenix6.signals.NeutralModeValue;
 
 public class MotorUtils {
   /** Sets brake mode for TalonFX motors */
-  public static void setBrakeMode(TalonFX motor, boolean brakeMode) {
+  public static void setIdleMode(TalonFX motor, MotorIdleMode idleMode) {
     MotorOutputConfigs motorOutputConfigs = new MotorOutputConfigs();
 
     motor.getConfigurator().refresh(motorOutputConfigs);
-    motorOutputConfigs.NeutralMode = brakeMode ? NeutralModeValue.Brake : NeutralModeValue.Coast;
+    motorOutputConfigs.NeutralMode = idleMode.forTalonFX();
 
     motor.getConfigurator().apply(motorOutputConfigs);
   }

--- a/src/main/java/frc/robot/util/SparkAdapter.java
+++ b/src/main/java/frc/robot/util/SparkAdapter.java
@@ -13,7 +13,6 @@ import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkFlex;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkBaseConfig;
-import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkBaseConfigAccessor;
 import com.revrobotics.spark.config.SparkFlexConfig;
 import com.revrobotics.spark.config.SparkMaxConfig;
@@ -130,15 +129,15 @@ public final class SparkAdapter implements MotorController {
    *
    * @param spark The SparkMax object to adapt.
    * @param isInverted Whether the motor should be inverted.
-   * @param brakeMode Whether the motor should brake when stopped.
+   * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public SparkAdapter(
-      SparkMax sparkMax, boolean isInverted, boolean brakeMode, double metersPerRotation) {
+      SparkMax sparkMax, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
     this(sparkMax);
 
-    configure(isInverted, brakeMode, metersPerRotation);
+    configure(isInverted, idleMode, metersPerRotation);
   }
 
   /**
@@ -159,29 +158,29 @@ public final class SparkAdapter implements MotorController {
    *
    * @param spark The SparkFlex object to adapt.
    * @param isInverted Whether the motor should be inverted.
-   * @param brakeMode Whether the motor should brake when stopped.
+   * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public SparkAdapter(
-      SparkFlex sparkFlex, boolean isInverted, boolean brakeMode, double metersPerRotation) {
+      SparkFlex sparkFlex, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
     this(sparkFlex);
 
-    configure(isInverted, brakeMode, metersPerRotation);
+    configure(isInverted, idleMode, metersPerRotation);
   }
 
   /**
    * Configures the motor controller.
    *
    * @param isInverted Whether the motor should be inverted.
-   * @param brakeMode Whether the motor should brake when stopped.
+   * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
-  private void configure(boolean isInverted, boolean brakeMode, double metersPerRotation) {
+  private void configure(boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
     SparkBaseConfig driveMotorConfig = spark.getConfig();
 
-    driveMotorConfig.inverted(isInverted).idleMode(brakeMode ? IdleMode.kBrake : IdleMode.kCoast);
+    driveMotorConfig.inverted(isInverted).idleMode(idleMode.forSpark());
 
     driveMotorConfig
         .encoder
@@ -224,10 +223,10 @@ public final class SparkAdapter implements MotorController {
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
+  public void setIdleMode(MotorIdleMode idleMode) {
     SparkBaseConfig config = spark.getConfig();
 
-    config.idleMode(brakeMode ? IdleMode.kBrake : IdleMode.kCoast);
+    config.idleMode(idleMode.forSpark());
 
     spark
         .get()

--- a/src/main/java/frc/robot/util/TalonFXAdapter.java
+++ b/src/main/java/frc/robot/util/TalonFXAdapter.java
@@ -12,7 +12,6 @@ import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.ForwardLimitValue;
 import com.ctre.phoenix6.signals.InvertedValue;
-import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.ReverseLimitValue;
 import edu.wpi.first.units.measure.Voltage;
 
@@ -42,16 +41,16 @@ public final class TalonFXAdapter implements MotorController {
    *
    * @param talonFX The TalonFX object to adapt.
    * @param isInverted Whether the motor should be inverted.
-   * @param brakeMode Whether the motor should brake when stopped.
+   * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public TalonFXAdapter(
-      TalonFX talonFX, boolean isInverted, boolean brakeMode, double metersPerRotation) {
+      TalonFX talonFX, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
     this(talonFX, metersPerRotation);
     MotorOutputConfigs motorOutputConfigs = new MotorOutputConfigs();
 
-    motorOutputConfigs.NeutralMode = brakeMode ? NeutralModeValue.Brake : NeutralModeValue.Coast;
+    motorOutputConfigs.NeutralMode = idleMode.forTalonFX();
     motorOutputConfigs.Inverted =
         isInverted ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
 
@@ -94,13 +93,8 @@ public final class TalonFXAdapter implements MotorController {
   }
 
   @Override
-  public void setBrakeMode(boolean brakeMode) {
-    MotorOutputConfigs motorOutputConfigs = new MotorOutputConfigs();
-
-    talonFX.getConfigurator().refresh(motorOutputConfigs);
-    motorOutputConfigs.NeutralMode = brakeMode ? NeutralModeValue.Brake : NeutralModeValue.Coast;
-
-    talonFX.getConfigurator().apply(motorOutputConfigs);
+  public void setIdleMode(MotorIdleMode idleMode) {
+    MotorUtils.setIdleMode(talonFX, idleMode);
   }
 
   @Override


### PR DESCRIPTION
This change renames `setBrakeMode` to `setIdleMode` and uses an enum to represent the desired mode rather than a Boolean value.

This change also resets the coast mode timer to prevent continuously setting the mode in `disabledPeriodic`. Making motor controller configuration changes is a blocking operation and can cause robot periodic loop overruns.