### PR TITLE
Improves clarity of motor direction control

### DIFF
--- a/src/main/java/frc/robot/parameters/MotorParameters.java
+++ b/src/main/java/frc/robot/parameters/MotorParameters.java
@@ -13,6 +13,7 @@ import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import edu.wpi.first.math.system.plant.DCMotor;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorDirection;
 import frc.robot.util.MotorIdleMode;
 import frc.robot.util.SparkAdapter;
 import frc.robot.util.TalonFXAdapter;
@@ -97,28 +98,28 @@ public enum MotorParameters {
    * Returns a new {@link MotorController} implementation for this motor type.
    *
    * @param deviceID The CAN device ID.
-   * @param isInverted Whether the motor should be inverted.
+   * @param direction The direction the motor rotates when a positive voltage is applied.
    * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    * @return A new MotorController implementation.
    */
   public MotorController newController(
-      int deviceID, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
+      int deviceID, MotorDirection direction, MotorIdleMode idleMode, double metersPerRotation) {
     switch (this) {
       case Falcon500:
       case KrakenX60:
-        return new TalonFXAdapter(new TalonFX(deviceID), isInverted, idleMode, metersPerRotation);
+        return new TalonFXAdapter(new TalonFX(deviceID), direction, idleMode, metersPerRotation);
 
       case NeoV1_1:
       case NeoVortexMax:
       case Neo550:
         return new SparkAdapter(
-            new SparkMax(deviceID, MotorType.kBrushless), isInverted, idleMode, metersPerRotation);
+            new SparkMax(deviceID, MotorType.kBrushless), direction, idleMode, metersPerRotation);
 
       case NeoVortexFlex:
         return new SparkAdapter(
-            new SparkFlex(deviceID, MotorType.kBrushless), isInverted, idleMode, metersPerRotation);
+            new SparkFlex(deviceID, MotorType.kBrushless), direction, idleMode, metersPerRotation);
 
       default:
         throw new UnsupportedOperation("Unknown Motor Type");

--- a/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Newport Robotics Group. All Rights Reserved.
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
  *
  * Open Source Software; you can modify and/or share it under the terms of
  * the license file in the root directory of this project.
@@ -12,6 +12,8 @@ import static frc.robot.parameters.MotorParameters.KrakenX60;
 import static frc.robot.parameters.MotorParameters.NeoV1_1;
 import static frc.robot.parameters.SwerveModuleParameters.MK4IFast;
 import static frc.robot.parameters.SwerveModuleParameters.MK4IFaster;
+import static frc.robot.util.MotorDirection.COUNTER_CLOCKWISE_POSITIVE;
+import static frc.robot.util.MotorIdleMode.BRAKE;
 
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.CANcoderConfigurator;
@@ -26,7 +28,7 @@ import edu.wpi.first.math.trajectory.constraint.SwerveDriveKinematicsConstraint;
 import edu.wpi.first.math.util.Units;
 import frc.robot.util.Gyro;
 import frc.robot.util.MotorController;
-import frc.robot.util.MotorIdleMode;
+import frc.robot.util.MotorDirection;
 import frc.robot.util.NavXGyro;
 import frc.robot.util.Pigeon2Gyro;
 
@@ -498,11 +500,10 @@ public enum SwerveDriveParameters {
       case BackRightDrive:
         final double metersPerRotation = (getWheelDiameter() * Math.PI) / getDriveGearRatio();
         return this.driveMotor.newController(
-            motorID, false, MotorIdleMode.BRAKE, metersPerRotation);
+            motorID, COUNTER_CLOCKWISE_POSITIVE, BRAKE, metersPerRotation);
 
       default:
-        return this.steeringMotor.newController(
-            motorID, isSteeringInverted(), MotorIdleMode.BRAKE, 1.0);
+        return this.steeringMotor.newController(motorID, getSteeringDirection(), BRAKE, 1.0);
     }
   }
 
@@ -679,12 +680,14 @@ public enum SwerveDriveParameters {
   }
 
   /**
-   * Returns true if the steering motor is inverted.
+   * Returns the direction the steering motor must rotate when a positive voltage is applied to
+   * rotate the wheel in the counter-clockwise direction.
    *
-   * @return Whether the steering motor is inverted.
+   * @return The direction the steering motor must rotate when a positive voltage is applied to
+   *     rotate the wheel in the counter-clockwise direction.
    */
-  public boolean isSteeringInverted() {
-    return swerveModule.isSteeringInverted();
+  public MotorDirection getSteeringDirection() {
+    return swerveModule.getSteeringDirection();
   }
 
   /** Returns the correct gyro implementation for the robot. */

--- a/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Newport Robotics Group. All Rights Reserved.
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
  *
  * Open Source Software; you can modify and/or share it under the terms of
  * the license file in the root directory of this project.
@@ -7,7 +7,11 @@
  
 package frc.robot.parameters;
 
-import frc.robot.Constants;
+import static frc.robot.Constants.RobotConstants.WHEEL_DIAMETER;
+import static frc.robot.util.MotorDirection.CLOCKWISE_POSITIVE;
+import static frc.robot.util.MotorDirection.COUNTER_CLOCKWISE_POSITIVE;
+
+import frc.robot.util.MotorDirection;
 
 /**
  * A enum representing the properties on a specific swerve drive module.
@@ -24,35 +28,35 @@ import frc.robot.Constants;
 public enum SwerveModuleParameters {
 
   /** An MK4 Swerve Module in the L1 - Standard configuration. */
-  MK4Standard(Constants.RobotConstants.WHEEL_DIAMETER, 8.14, 12.8, false),
+  MK4Standard(WHEEL_DIAMETER, 8.14, 12.8, COUNTER_CLOCKWISE_POSITIVE),
 
   /** An MK4 Swerve Module in the L2 - Fast configuration. */
-  MK4Fast(Constants.RobotConstants.WHEEL_DIAMETER, 6.75, 12.8, false),
+  MK4Fast(WHEEL_DIAMETER, 6.75, 12.8, COUNTER_CLOCKWISE_POSITIVE),
 
   /** An MK4 Swerve Module in the L3 - Very Fast configuration. */
-  MK4VeryFast(Constants.RobotConstants.WHEEL_DIAMETER, 6.12, 12.8, false),
+  MK4VeryFast(WHEEL_DIAMETER, 6.12, 12.8, COUNTER_CLOCKWISE_POSITIVE),
 
   /** An MK4 Swerve Module in the L4 - Too Fast configuration. */
-  MK4TooFast(Constants.RobotConstants.WHEEL_DIAMETER, 5.14, 12.8, false),
+  MK4TooFast(WHEEL_DIAMETER, 5.14, 12.8, COUNTER_CLOCKWISE_POSITIVE),
 
   /** An MK4I Swerve Module in the L1 - Standard configuration. */
-  MK4IStandard(Constants.RobotConstants.WHEEL_DIAMETER, 8.14, 150.0 / 7.0, true),
+  MK4IStandard(WHEEL_DIAMETER, 8.14, 150.0 / 7.0, CLOCKWISE_POSITIVE),
 
   /** An MK4I Swerve Module in the L2 - Fast configuration. */
-  MK4IFast(Constants.RobotConstants.WHEEL_DIAMETER, 6.75, 150.0 / 7.0, true),
+  MK4IFast(WHEEL_DIAMETER, 6.75, 150.0 / 7.0, CLOCKWISE_POSITIVE),
 
   /** An MK4I Swerve Module in the L2+ - Faster configuration. */
-  MK4IFaster(Constants.RobotConstants.WHEEL_DIAMETER, 5.9, 150.0 / 7.0, true),
+  MK4IFaster(WHEEL_DIAMETER, 5.9, 150.0 / 7.0, CLOCKWISE_POSITIVE),
 
   /** An MK4I Swerve Module in the L3 - Very Fast configuration. */
-  MK4IVeryFast(Constants.RobotConstants.WHEEL_DIAMETER, 6.12, 150.0 / 7.0, true);
+  MK4IVeryFast(WHEEL_DIAMETER, 6.12, 150.0 / 7.0, CLOCKWISE_POSITIVE);
 
   /** */
   private final double wheelDiameter;
 
   private final double driveGearRatio;
   private final double steeringGearRatio;
-  private final boolean steeringInverted;
+  private final MotorDirection steeringDirection;
 
   /**
    * Constructs an instance of this enum.
@@ -60,16 +64,18 @@ public enum SwerveModuleParameters {
    * @param wheelDiameter The wheel diameter in meters.
    * @param driveGearRatio The drive gear ratio.
    * @param steeringGearRatio The steering gear ratio.
+   * @param steeringDirection The direction the steering motor must rotate when a positive voltage
+   *     is applied to rotate the wheel in the counter-clockwise direction.
    */
   SwerveModuleParameters(
       double wheelDiameter,
       double driveGearRatio,
       double steeringGearRatio,
-      boolean steeringInverted) {
+      MotorDirection steeringDirection) {
     this.wheelDiameter = wheelDiameter;
     this.driveGearRatio = driveGearRatio;
     this.steeringGearRatio = steeringGearRatio;
-    this.steeringInverted = steeringInverted;
+    this.steeringDirection = steeringDirection;
   }
 
   /**
@@ -100,12 +106,14 @@ public enum SwerveModuleParameters {
   }
 
   /**
-   * Returns true if the steering motor is inverted.
+   * Returns the direction the steering motor must rotate when a positive voltage is applied to
+   * rotate the wheel in the counter-clockwise direction.
    *
-   * @return Whether the steering motor is inverted.
+   * @return The direction the steering motor must rotate when a positive voltage is applied to
+   *     rotate the wheel in the counter-clockwise direction.
    */
-  public boolean isSteeringInverted() {
-    return this.steeringInverted;
+  public MotorDirection getSteeringDirection() {
+    return this.steeringDirection;
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.RobotConstants;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorDirection;
 import frc.robot.util.MotorIdleMode;
 import frc.robot.util.TalonFXAdapter;
 
@@ -70,7 +71,7 @@ public class Climber extends SubsystemBase implements ShuffleboardProducer, Acti
   private TalonFXAdapter mainMotor =
       new TalonFXAdapter(
           new TalonFX(RobotConstants.CAN.TalonFX.CLIMBER_MAIN_MOTOR_ID, "rio"),
-          false,
+          MotorDirection.COUNTER_CLOCKWISE_POSITIVE,
           MotorIdleMode.BRAKE,
           1); // filler value; motor encoder value is not used.
 

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -41,6 +41,7 @@ import frc.robot.commands.ElevatorCommands;
 import frc.robot.parameters.ElevatorLevel;
 import frc.robot.parameters.ElevatorParameters;
 import frc.robot.util.MotorController;
+import frc.robot.util.MotorDirection;
 import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
@@ -114,7 +115,7 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
   private TalonFXAdapter mainMotor =
       new TalonFXAdapter(
           new TalonFX(PARAMETERS.getValue().getMainDeviceID(), "rio"),
-          false,
+          MotorDirection.COUNTER_CLOCKWISE_POSITIVE,
           MotorIdleMode.BRAKE,
           METERS_PER_REVOLUTION);
 
@@ -312,7 +313,7 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
       if (goalState.position == MIN_HEIGHT
           && !MathUtil.isNear(MIN_HEIGHT, currentState.position, STOWED_POSITION_TOLERANCE)
           && currentState.velocity == 0) {
-        encoder.reset(); 
+        encoder.reset();
       }
     }
   }

--- a/src/main/java/frc/robot/util/MotorDirection.java
+++ b/src/main/java/frc/robot/util/MotorDirection.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
+ *
+ * Open Source Software; you can modify and/or share it under the terms of
+ * the license file in the root directory of this project.
+ */
+ 
+package frc.robot.util;
+
+import com.ctre.phoenix6.signals.InvertedValue;
+
+/** The direction the motor output shaft rotates when positive voltage is applied. */
+public enum MotorDirection {
+  /** The motor output shaft rotates counter-clockwise when positive voltage is applied. */
+  COUNTER_CLOCKWISE_POSITIVE(InvertedValue.CounterClockwise_Positive),
+
+  /** The motor output shaft rotates clockwise when positive voltage is applied. */
+  CLOCKWISE_POSITIVE(InvertedValue.Clockwise_Positive);
+
+  private final InvertedValue invertedValue;
+
+  /**
+   * Constructs a variant of this enum.
+   *
+   * @param invertedValue The corresponding {@link InvertedValue} variant for the TalonFX.
+   */
+  MotorDirection(InvertedValue invertedValue) {
+    this.invertedValue = invertedValue;
+  }
+
+  /** Returns the corresponding {@link InvertedValue} variant for the TalonFX. */
+  public InvertedValue forTalonFX() {
+    return invertedValue;
+  }
+
+  /**
+   * Returns true if the motor rotates in the clockwise direction when a positive voltage is applied
+   * (i.e. the motor is "inverted"). Otherwise, this method returns false if the motor rotates in
+   * the counter-clockwise direction.
+   */
+  public boolean isInverted() {
+    return this == CLOCKWISE_POSITIVE;
+  }
+}

--- a/src/main/java/frc/robot/util/SparkAdapter.java
+++ b/src/main/java/frc/robot/util/SparkAdapter.java
@@ -128,16 +128,19 @@ public final class SparkAdapter implements MotorController {
    * Constructs a SparkAdapter for a {@link SparkMax} motor controller.
    *
    * @param spark The SparkMax object to adapt.
-   * @param isInverted Whether the motor should be inverted.
+   * @param direction The direction the motor rotates when a positive voltage is applied.
    * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public SparkAdapter(
-      SparkMax sparkMax, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
+      SparkMax sparkMax,
+      MotorDirection direction,
+      MotorIdleMode idleMode,
+      double metersPerRotation) {
     this(sparkMax);
 
-    configure(isInverted, idleMode, metersPerRotation);
+    configure(direction, idleMode, metersPerRotation);
   }
 
   /**
@@ -157,30 +160,34 @@ public final class SparkAdapter implements MotorController {
    * Constructs a SparkAdapter for a {@link SparkFlex} motor controller.
    *
    * @param spark The SparkFlex object to adapt.
-   * @param isInverted Whether the motor should be inverted.
+   * @param direction The direction the motor rotates when a positive voltage is applied.
    * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public SparkAdapter(
-      SparkFlex sparkFlex, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
+      SparkFlex sparkFlex,
+      MotorDirection direction,
+      MotorIdleMode idleMode,
+      double metersPerRotation) {
     this(sparkFlex);
 
-    configure(isInverted, idleMode, metersPerRotation);
+    configure(direction, idleMode, metersPerRotation);
   }
 
   /**
    * Configures the motor controller.
    *
-   * @param isInverted Whether the motor should be inverted.
+   * @param direction The direction the motor rotates when a positive voltage is applied.
    * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
-  private void configure(boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
+  private void configure(
+      MotorDirection direction, MotorIdleMode idleMode, double metersPerRotation) {
     SparkBaseConfig driveMotorConfig = spark.getConfig();
 
-    driveMotorConfig.inverted(isInverted).idleMode(idleMode.forSpark());
+    driveMotorConfig.inverted(direction.isInverted()).idleMode(idleMode.forSpark());
 
     driveMotorConfig
         .encoder

--- a/src/main/java/frc/robot/util/TalonFXAdapter.java
+++ b/src/main/java/frc/robot/util/TalonFXAdapter.java
@@ -40,19 +40,18 @@ public final class TalonFXAdapter implements MotorController {
    * Constructs a TalonFXAdapter.
    *
    * @param talonFX The TalonFX object to adapt.
-   * @param isInverted Whether the motor should be inverted.
+   * @param direction The direction the motor rotates when a positive voltage is applied.
    * @param idleMode The motor behavior when idle (i.e. brake or coast mode).
    * @param metersPerRotation The distance in meters the attached mechanism moves per rotation of
    *     the output shaft.
    */
   public TalonFXAdapter(
-      TalonFX talonFX, boolean isInverted, MotorIdleMode idleMode, double metersPerRotation) {
+      TalonFX talonFX, MotorDirection direction, MotorIdleMode idleMode, double metersPerRotation) {
     this(talonFX, metersPerRotation);
     MotorOutputConfigs motorOutputConfigs = new MotorOutputConfigs();
 
     motorOutputConfigs.NeutralMode = idleMode.forTalonFX();
-    motorOutputConfigs.Inverted =
-        isInverted ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
+    motorOutputConfigs.Inverted = direction.forTalonFX();
 
     talonFX.getConfigurator().apply(motorOutputConfigs);
   }


### PR DESCRIPTION
This change replaces a Boolean "inverted" value with a `MotorDirection` enum that more clearly indicate the direction the motor rotates when a positive voltage is applied.