### PR TITLE
Fixes follower motor configuration

### DIFF
--- a/src/main/java/frc/robot/util/TalonFXAdapter.java
+++ b/src/main/java/frc/robot/util/TalonFXAdapter.java
@@ -113,7 +113,14 @@ public final class TalonFXAdapter implements MotorController {
     // Get the motor output configuration from the leader and apply it to the follower.
     MotorOutputConfigs followerMotorOutputConfigs = new MotorOutputConfigs();
 
-    followerMotorOutputConfigs.deserialize(motorOutputConfigs.serialize());
+    followerMotorOutputConfigs.Inverted = motorOutputConfigs.Inverted;
+    followerMotorOutputConfigs.NeutralMode = motorOutputConfigs.NeutralMode;
+    followerMotorOutputConfigs.DutyCycleNeutralDeadband =
+        motorOutputConfigs.DutyCycleNeutralDeadband;
+    followerMotorOutputConfigs.PeakForwardDutyCycle = motorOutputConfigs.PeakForwardDutyCycle;
+    followerMotorOutputConfigs.PeakReverseDutyCycle = motorOutputConfigs.PeakReverseDutyCycle;
+    followerMotorOutputConfigs.ControlTimesyncFreqHz = motorOutputConfigs.ControlTimesyncFreqHz;
+
     applyConfig(follower, followerMotorOutputConfigs);
 
     // Configure the follower to follow the leader.


### PR DESCRIPTION
Deserializing from the serialized `MotorOutputConfigs` produced by its `serialize()` method doesn't correctly preserve some fields. Worse, it sets them to invalid values causing the application of the config to fail with an `InvalidParamError` error.

This change manually copies all of the fields from the main to the follower motor output config before applying it.

Tested through simulation.