### PR TITLE
Applies changes made during Steamnasium test session

### DIFF
--- a/src/main/java/frc/robot/parameters/ElevatorLevel.java
+++ b/src/main/java/frc/robot/parameters/ElevatorLevel.java
@@ -12,7 +12,7 @@ import frc.robot.subsystems.Elevator;
 public enum ElevatorLevel {
   // TODO: Determine correct values for height, arm angles and arm offset.
   STOWED(Elevator.STOWED_HEIGHT_FOR_PID, Math.toRadians(90), 0),
-  L1(0.3, Math.toRadians(95), .2),
+  L1(0.3, Math.toRadians(95), .2), // Assumes we shoot the coral in-line with the L1 shelf
   L2(0.37, Math.toRadians(60), .2),
   L3(0.78, Math.toRadians(60), .2),
   L4(1.4, Math.toRadians(50), .2),

--- a/src/main/java/frc/robot/parameters/ElevatorLevel.java
+++ b/src/main/java/frc/robot/parameters/ElevatorLevel.java
@@ -12,7 +12,7 @@ import frc.robot.subsystems.Elevator;
 public enum ElevatorLevel {
   // TODO: Determine correct values for height, arm angles and arm offset.
   STOWED(Elevator.STOWED_HEIGHT_FOR_PID, Math.toRadians(90), 0),
-  L1(0.375, Math.toRadians(60), .2),
+  L1(0.3, Math.toRadians(95), .2),
   L2(0.37, Math.toRadians(60), .2),
   L3(0.78, Math.toRadians(60), .2),
   L4(1.4, Math.toRadians(50), .2),

--- a/src/main/java/frc/robot/parameters/VisionParameters.java
+++ b/src/main/java/frc/robot/parameters/VisionParameters.java
@@ -31,7 +31,7 @@ public enum VisionParameters {
               new Rotation3d())),
       Optional.of(
           new Transform3d(
-              new Translation3d(Units.inchesToMeters(-13), -0.255, -0.8175),
+              new Translation3d(Units.inchesToMeters(-13), -0.255, -0.8175), // y & z in meters
               new Rotation3d(0, 0, Math.toRadians(180)))));
 
   private final Optional<Transform3d> frontCamera;

--- a/src/main/java/frc/robot/parameters/VisionParameters.java
+++ b/src/main/java/frc/robot/parameters/VisionParameters.java
@@ -25,16 +25,13 @@ public enum VisionParameters {
       Optional.of(
           new Transform3d(
               new Translation3d(
-                  Units.inchesToMeters(14.25),
-                  Units.inchesToMeters(-9.5625),
-                  Units.inchesToMeters(12)),
+                  Units.inchesToMeters(11),
+                  Units.inchesToMeters(-10.25),
+                  Units.inchesToMeters(12.625)),
               new Rotation3d())),
       Optional.of(
           new Transform3d(
-              new Translation3d(
-                  Units.inchesToMeters(0.75),
-                  Units.inchesToMeters(-5),
-                  Units.inchesToMeters(36.875)),
+              new Translation3d(Units.inchesToMeters(-13), -0.255, -0.8175),
               new Rotation3d(0, 0, Math.toRadians(180)))));
 
   private final Optional<Transform3d> frontCamera;

--- a/src/main/java/frc/robot/subsystems/CoralRoller.java
+++ b/src/main/java/frc/robot/subsystems/CoralRoller.java
@@ -37,12 +37,20 @@ import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
 import java.util.Set;
 
-@RobotPreferencesLayout(groupName = "CoralRoller", row = 2, column = 0, width = 1, height = 1)
+@RobotPreferencesLayout(groupName = "CoralRoller", row = 2, column = 0, width = 1, height = 2)
 public class CoralRoller extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
 
   @RobotPreferencesValue
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("CoralRoller", "Enable Tab", false);
+
+  @RobotPreferencesValue
+  public static final RobotPreferences.DoubleValue INTAKE_VELOCITY =
+      new RobotPreferences.DoubleValue("CoralRoller", "Intake Velocity", 1);
+
+  @RobotPreferencesValue
+  public static final RobotPreferences.DoubleValue OUTTAKE_VELOCITY =
+      new RobotPreferences.DoubleValue("CoralRoller", "Outtake Velocity", 2);
 
   private static final DataLog LOG = DataLogManager.getLog();
 
@@ -95,12 +103,12 @@ public class CoralRoller extends SubsystemBase implements ActiveSubsystem, Shuff
 
   /** Intakes the coral. */
   public void intake() {
-    setGoalVelocity(MAX_VELOCITY);
+    setGoalVelocity(INTAKE_VELOCITY.getValue());
   }
 
   /** Outakes the coral. */
   public void outtake() {
-    setGoalVelocity(MAX_VELOCITY);
+    setGoalVelocity(OUTTAKE_VELOCITY.getValue());
     outtakeTimer.restart();
   }
 

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -65,7 +65,7 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
       new RobotPreferences.BooleanValue("Elevator", "Enable Tab", false);
 
   // physical parameters of the elevator
-  public static final double PRACTICE_BOT_GEAR_RATIO = ((60.0 / 12.0) * (15.0 / 15.0)) / 2;
+  public static final double PRACTICE_BOT_GEAR_RATIO = ((60.0 / 12.0) * (24.0 / 15.0)) / 2;
   public static final double COMP_BOT_GEAR_RATIO = ((60.0 / 12.0) * (24.0 / 15.0)) / 2;
   private static final double GEAR_RATIO = PARAMETERS.getValue().getGearRatio();
   private static final double SPROCKET_DIAMETER = 0.0474; // in meters


### PR DESCRIPTION
Applies the following changes:

1. Updates the practice 'bot camera transforms.
2. Adds intake and outtake velocity preferences to the `CoralRoller` subsystem.
3. Restores the practice 'bot elevator gear ratio.
4. Sets the L1 scoring height to support delivering the coral in-line with the L1 shelf.