### PR TITLE
Abstracts angle encoders & adds a REV Throughbore implementation

### DIFF
--- a/src/main/java/frc/robot/parameters/ArmParameters.java
+++ b/src/main/java/frc/robot/parameters/ArmParameters.java
@@ -30,7 +30,7 @@ public enum ArmParameters {
       // reading the raw value of the absolute encoder to obtain the zero point,
       // we must invert the value by subtracting it from 1 before converting it
       // to radians.
-      Math.toRadians(360 - 10.55),
+      Math.toRadians(10.55),
       Math.toRadians(10),
       Math.toRadians(95)),
   AlgaeArm(
@@ -43,7 +43,7 @@ public enum ArmParameters {
       RobotConstants.CAN.TalonFX.ALGAE_ARM_MOTOR_ID,
       RobotConstants.DigitalIO.ALGAE_ARM_ABSOLUTE_ENCODER,
       false, // TODO: determine inversion
-      0, // TODO: get real encoder offset
+      Math.toRadians(0), // TODO: get real encoder offset
       Math.toRadians(45),
       Math.toRadians(90));
 

--- a/src/main/java/frc/robot/util/AbsoluteAngleEncoder.java
+++ b/src/main/java/frc/robot/util/AbsoluteAngleEncoder.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
+ *
+ * Open Source Software; you can modify and/or share it under the terms of
+ * the license file in the root directory of this project.
+ */
+ 
+package frc.robot.util;
+
+/** An interface for absolute angle encoders. */
+public interface AbsoluteAngleEncoder {
+  /** Returns the angle in with range -π to π radians */
+  double getAngle();
+}

--- a/src/main/java/frc/robot/util/RevThroughboreEncoderAdapter.java
+++ b/src/main/java/frc/robot/util/RevThroughboreEncoderAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Newport Robotics Group. All Rights Reserved.
+ *
+ * Open Source Software; you can modify and/or share it under the terms of
+ * the license file in the root directory of this project.
+ */
+ 
+package frc.robot.util;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DutyCycleEncoder;
+
+/**
+ * An adapter for the <a href="https://www.revrobotics.com/rev-11-1271/">Rev Throughbore Encoder</a>
+ * to implement the AbsoluteAngleEncoder interface.
+ */
+public class RevThroughboreEncoderAdapter implements AbsoluteAngleEncoder {
+  private static final double DUTY_CYCLE_PERIOD = 1025.0;
+  private static final double MIN_DUTY_CYCLE = 1.0 / DUTY_CYCLE_PERIOD;
+  private static final double MAX_DUTY_CYCLE = 1024.0 / 1025.0;
+
+  private static final double RANGE = 2 * Math.PI;
+
+  private final DutyCycleEncoder encoder;
+
+  /**
+   * Creates a new RevThroughboreEncoderAdapter.
+   *
+   * @param channel The digital input channel for the encoder.
+   * @param inverted Whether the encoder is inverted.
+   * @param zeroPoint The zero point of the encoder in radians with range -π to π radians.
+   *     <p>To get this value, set it to zero initially and read the value from the encoder. Pass
+   *     the observed value here.
+   */
+  public RevThroughboreEncoderAdapter(int channel, boolean inverted, double zeroPoint) {
+    // The DutyCycleEncoder outputs a value between 0 and 2*π radians, so we need to adjust the
+    // zero point to be in that range.
+    zeroPoint = MathUtil.inputModulus(zeroPoint, 0, 2 * Math.PI);
+
+    if (inverted) {
+      // The DutyCycleEncoder implementation applies inversion after adjusting the zero point,
+      // so we need to subtract the specified zero point from the maximum range value to
+      // get the correct value.
+      zeroPoint = RANGE - zeroPoint;
+    }
+
+    this.encoder = new DutyCycleEncoder(channel, RANGE, zeroPoint);
+    this.encoder.setDutyCycleRange(MIN_DUTY_CYCLE, MAX_DUTY_CYCLE);
+    this.encoder.setInverted(inverted);
+  }
+
+  @Override
+  public double getAngle() {
+    return MathUtil.angleModulus(encoder.get());
+  }
+}

--- a/src/main/java/frc/robot/util/TalonFXEncoderAdapter.java
+++ b/src/main/java/frc/robot/util/TalonFXEncoderAdapter.java
@@ -39,16 +39,22 @@ public final class TalonFXEncoderAdapter implements RelativeEncoder {
 
   @Override
   public void setPosition(double position) {
-    talonFX.setPosition(position);
+    // The TalonFX encoder position is in units of rotations, so we need to divide by the
+    // distance per rotation to get the position in encoder units.
+    talonFX.setPosition(position / distancePerRotation);
   }
 
   @Override
   public double getPosition() {
+    // The TalonFX encoder position is in units of rotations, so we need to multiply by the
+    // distance per rotation to get the position in the correct units.
     return position.refresh().getValueAsDouble() * distancePerRotation;
   }
 
   @Override
   public double getVelocity() {
+    // The TalonFX encoder velocity is in units of rotations per second, so we need to multiply by
+    // the distance per rotation to get the velocity in the correct units.
     return velocity.refresh().getValueAsDouble() * distancePerRotation;
   }
 


### PR DESCRIPTION
This change normalizes the output range of absolute angle encoders to -π to π radians. It also makes the `distancePerRotation` parameter consistent between `getPosition` and `setPosition` on the `TalonFXEncoderAdapter` implementation.