### PR TITLE
Uses kS derived from motor specifications

### DIFF
--- a/src/main/java/frc/robot/parameters/AlgaeArmParameters.java
+++ b/src/main/java/frc/robot/parameters/AlgaeArmParameters.java
@@ -25,8 +25,6 @@ public enum AlgaeArmParameters implements ArmParameters {
       2.086,
       9.0,
       Units.inchesToMeters(8),
-      1,
-      0.0656,
       ALGAE_ARM_MOTOR_ID,
       ALGAE_ARM_ABSOLUTE_ENCODER,
       true,
@@ -39,8 +37,6 @@ public enum AlgaeArmParameters implements ArmParameters {
       2.086,
       9.0,
       Units.inchesToMeters(8),
-      1,
-      0.0656,
       ALGAE_ARM_MOTOR_ID,
       ALGAE_ARM_ABSOLUTE_ENCODER,
       true,
@@ -52,7 +48,6 @@ public enum AlgaeArmParameters implements ArmParameters {
   private final double gearRatio;
   private final double mass;
   private final double armLength;
-  private final double efficiency;
   private final int motorID;
   private final int encoderID;
   private final double minAngleRad;
@@ -73,8 +68,6 @@ public enum AlgaeArmParameters implements ArmParameters {
    * @param mass The mass of the arm.
    * @param gearRatio The gear ratio.
    * @param armLength The length of the arm.
-   * @param efficiency The efficiency of the arm.
-   * @param kS The kS feedforward constant in volts.
    * @param motorID The CAN ID of the motor.
    * @param encoderID The absolute encoder ID.
    * @param absoluteEncoderInverted Whether the absolute encoder is inverted.
@@ -88,8 +81,6 @@ public enum AlgaeArmParameters implements ArmParameters {
       double mass,
       double gearRatio,
       double armLength,
-      double efficiency,
-      double kS,
       int motorID,
       int encoderID,
       boolean absoluteEncoderInverted,
@@ -100,8 +91,7 @@ public enum AlgaeArmParameters implements ArmParameters {
     this.motorParameters = motorParameters;
     this.mass = mass;
     this.armLength = armLength;
-    this.efficiency = efficiency;
-    this.kS = kS;
+    this.kS = motorParameters.getKs();
     this.motorID = motorID;
     this.encoderID = encoderID;
     this.absoluteEncoderInverted = absoluteEncoderInverted;
@@ -158,11 +148,6 @@ public enum AlgaeArmParameters implements ArmParameters {
     return armLength;
   }
 
-  /** Returns the efficiency. */
-  public double getEfficiency() {
-    return efficiency;
-  }
-
   /** Returns the absolute encoder reading in radians at the designated 0 point of the mechanism */
   public double getAbsoluteEncoderZeroOffset() {
     return absoluteEncoderZeroOffset;
@@ -205,15 +190,12 @@ public enum AlgaeArmParameters implements ArmParameters {
 
   /** Returns the max angular speed in rad/s. */
   public double getMaxAngularSpeed() {
-    return (this.efficiency * this.motorParameters.getDCMotor().freeSpeedRadPerSec)
-        / this.gearRatio;
+    return (this.motorParameters.getDCMotor().freeSpeedRadPerSec) / this.gearRatio;
   }
 
   /** Returns the max angular acceleration in rad/s^2. */
   public double getMaxAngularAcceleration() {
-    return (this.efficiency
-            * this.motorParameters.getDCMotor().stallTorqueNewtonMeters
-            * this.gearRatio)
+    return (this.motorParameters.getDCMotor().stallTorqueNewtonMeters * this.gearRatio)
         / (this.mass * this.armLength);
   }
 

--- a/src/main/java/frc/robot/parameters/ArmParameters.java
+++ b/src/main/java/frc/robot/parameters/ArmParameters.java
@@ -40,9 +40,6 @@ public interface ArmParameters {
   /** Returns the robot arm length. */
   public double getArmLength();
 
-  /** Returns the efficiency. */
-  public double getEfficiency();
-
   /** Returns the absolute encoder reading in radians at the designated 0 point of the mechanism */
   public double getAbsoluteEncoderZeroOffset();
 

--- a/src/main/java/frc/robot/parameters/CoralArmParameters.java
+++ b/src/main/java/frc/robot/parameters/CoralArmParameters.java
@@ -25,8 +25,6 @@ public enum CoralArmParameters implements ArmParameters {
       1.25,
       3.0 * 9.0 * 54.0 / 36.0,
       0.315,
-      1,
-      0.0656,
       PRACTICE_CORAL_ARM_MOTOR_ID,
       CORAL_ARM_ABSOLUTE_ENCODER,
       true, // The absolute encoder is inverted.
@@ -39,8 +37,6 @@ public enum CoralArmParameters implements ArmParameters {
       1.25,
       9.0 * 54.0 / 36.0,
       0.315,
-      1,
-      0.0656,
       COMPETITION_CORAL_ARM_MOTOR_ID,
       CORAL_ARM_ABSOLUTE_ENCODER,
       true, // The absolute encoder is inverted.
@@ -53,7 +49,6 @@ public enum CoralArmParameters implements ArmParameters {
   private final double gearRatio;
   private final double mass;
   private final double armLength;
-  private final double efficiency;
   private final int motorID;
   private final int encoderID;
   private final double minAngleRad;
@@ -76,8 +71,6 @@ public enum CoralArmParameters implements ArmParameters {
    * @param mass The mass of the arm.
    * @param gearRatio The gear ratio.
    * @param armLength The length of the arm.
-   * @param efficiency The efficiency of the arm.
-   * @param kS The kS feedforward constant in volts.
    * @param motorID The CAN ID of the motor.
    * @param encoderID The absolute encoder ID.
    * @param absoluteEncoderInverted Whether the absolute encoder is inverted.
@@ -91,8 +84,6 @@ public enum CoralArmParameters implements ArmParameters {
       double mass,
       double gearRatio,
       double armLength,
-      double efficiency,
-      double kS,
       int motorID,
       int encoderID,
       boolean absoluteEncoderInverted,
@@ -104,8 +95,7 @@ public enum CoralArmParameters implements ArmParameters {
     this.motorParameters = motorParameters;
     this.mass = mass;
     this.armLength = armLength;
-    this.efficiency = efficiency;
-    this.kS = kS;
+    this.kS = motorParameters.getKs();
     this.motorID = motorID;
     this.encoderID = encoderID;
     this.absoluteEncoderInverted = absoluteEncoderInverted;
@@ -163,11 +153,6 @@ public enum CoralArmParameters implements ArmParameters {
     return armLength;
   }
 
-  /** Returns the efficiency. */
-  public double getEfficiency() {
-    return efficiency;
-  }
-
   /** Returns the absolute encoder reading in radians at the designated 0 point of the mechanism */
   public double getAbsoluteEncoderZeroOffset() {
     return absoluteEncoderZeroOffset;
@@ -210,15 +195,12 @@ public enum CoralArmParameters implements ArmParameters {
 
   /** Returns the max angular speed in rad/s. */
   public double getMaxAngularSpeed() {
-    return (this.efficiency * this.motorParameters.getDCMotor().freeSpeedRadPerSec)
-        / this.gearRatio;
+    return this.motorParameters.getDCMotor().freeSpeedRadPerSec / this.gearRatio;
   }
 
   /** Returns the max angular acceleration in rad/s^2. */
   public double getMaxAngularAcceleration() {
-    return (this.efficiency
-            * this.motorParameters.getDCMotor().stallTorqueNewtonMeters
-            * this.gearRatio)
+    return (this.motorParameters.getDCMotor().stallTorqueNewtonMeters * this.gearRatio)
         / (this.mass * this.armLength);
   }
 

--- a/src/main/java/frc/robot/parameters/MotorParameters.java
+++ b/src/main/java/frc/robot/parameters/MotorParameters.java
@@ -93,6 +93,11 @@ public enum MotorParameters {
     return this.motor.stallTorqueNewtonMeters;
   }
 
+  /** Returns the voltage required to overcome the internal resistance of the motor. */
+  public double getKs() {
+    return this.motor.rOhms * this.motor.freeCurrentAmps;
+  }
+
   /**
    * Returns a new {@link MotorController} implementation for this motor type.
    *

--- a/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
@@ -46,8 +46,6 @@ public enum SwerveDriveParameters {
       new int[] {13, 14, 8, 9, 19, 18, 6, 7}, // drive, steer motor controller CAN IDs
       new int[] {34, 33, 32, 31}, // CANCoder CAN IDs
       new double[] {22.85, 300.85, 324.67, 349.10},
-      0.15,
-      0.15,
       false,
       0),
   PracticeBase2025(
@@ -60,8 +58,6 @@ public enum SwerveDriveParameters {
       new int[] {17, 19, 18, 20, 1, 2, 9, 10}, // drive, steer motor controller CAN IDs
       new int[] {33, 34, 31, 32}, // CANCoder CAN IDs
       new double[] {137.29, 168.93, 167.17, 186.24}, // CANCoder offsets
-      0.0656,
-      0.2057,
       true,
       21),
   CompetitionBase2025(
@@ -74,8 +70,6 @@ public enum SwerveDriveParameters {
       new int[] {15, 14, 13, 6, 2, 1, 8, 7}, // drive, steer motor controller CAN IDs
       new int[] {31, 32, 33, 34}, // CANCoder CAN IDs
       new double[] {159.79, 109.25, 170.95, 4.66}, // CANCoder offsets
-      0.0656,
-      0.2057,
       true,
       21);
 
@@ -259,7 +253,6 @@ public enum SwerveDriveParameters {
    * @param angleOffset An array containing the zero point offsets for the swerve module angle
    *     encoders in the order front left, front right, back left, back right.
    * @param driveFeedforward The drive feedforward constants.
-   * @param steeringKs The steering Ks feedforward constant.
    * @param usesPigeon Whether the robot uses a Pigeon 2 or NavX MXP for its gyro.
    * @param pigeonID The CAN ID for the Pigeon 2 gyro if present.
    */
@@ -274,7 +267,6 @@ public enum SwerveDriveParameters {
       int[] angleEncoderIds,
       double[] angleOffset,
       FeedforwardConstants driveFeedForward,
-      double steeringkS,
       boolean usesPigeon,
       int pigeonID) {
     this(
@@ -289,7 +281,7 @@ public enum SwerveDriveParameters {
         angleOffset,
         driveFeedForward,
         new CalculatedFeedforwardConstants(
-            steeringkS,
+            steeringMotor.getKs(),
             () -> swerveModule.calculateMaxSteeringSpeed(steeringMotor),
             () -> swerveModule.calculateMaxSteeringAcceleration(steeringMotor, robotMass)),
         usesPigeon,
@@ -332,8 +324,6 @@ public enum SwerveDriveParameters {
    *     the order front left, front right, back left, back right.
    * @param angleOffset An array containing the zero point offsets for the swerve module angle
    *     encoders in the order front left, front right, back left, back right.
-   * @param driveKs The drive kS constant.
-   * @param steeringKs The steering kS constant.
    * @param usesPigeon Whether the robot uses a Pigeon 2 or NavX MXP for its gyro.
    * @param pigeonID The CAN ID for the Pigeon 2 gyro if present.
    */
@@ -347,8 +337,6 @@ public enum SwerveDriveParameters {
       int[] motorIds,
       int[] angleEncoderIds,
       double[] angleOffset,
-      double drivekS,
-      double steeringkS,
       boolean usesPigeon,
       int pigeonID) {
     this(
@@ -362,11 +350,11 @@ public enum SwerveDriveParameters {
         angleEncoderIds,
         angleOffset,
         new CalculatedFeedforwardConstants(
-            drivekS,
+            driveMotor.getKs(),
             () -> swerveModule.calculateMaxDriveSpeed(driveMotor),
             () -> swerveModule.calculateMaxDriveAcceleration(driveMotor, robotMass)),
         new CalculatedFeedforwardConstants(
-            steeringkS,
+            steeringMotor.getKs(),
             () -> swerveModule.calculateMaxSteeringSpeed(steeringMotor),
             () -> swerveModule.calculateMaxSteeringAcceleration(steeringMotor, robotMass)),
         usesPigeon,

--- a/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
@@ -9,6 +9,7 @@ package frc.robot.subsystems;
 
 import static frc.robot.Constants.RobotConstants.CAN.TalonFX.ALGAE_GRABBER_MOTOR_ID;
 import static frc.robot.Constants.RobotConstants.MAX_BATTERY_VOLTAGE;
+import static frc.robot.parameters.MotorParameters.KrakenX60;
 import static frc.robot.util.MotorDirection.CLOCKWISE_POSITIVE;
 import static frc.robot.util.MotorIdleMode.BRAKE;
 
@@ -68,7 +69,7 @@ public class AlgaeGrabber extends SubsystemBase implements ActiveSubsystem, Shuf
   private static final double MAX_VELOCITY =
       (MotorParameters.KrakenX60.getFreeSpeedRPM() * METERS_PER_REVOLUTION) / 60;
 
-  private static final double KS = 0.0656;
+  private static final double KS = KrakenX60.getKs();
   private static final double KV = (MAX_BATTERY_VOLTAGE - KS) / MAX_VELOCITY;
 
   private static final double ERROR_TIME = 3.0;

--- a/src/main/java/frc/robot/subsystems/CoralRoller.java
+++ b/src/main/java/frc/robot/subsystems/CoralRoller.java
@@ -10,6 +10,7 @@ package frc.robot.subsystems;
 import static frc.robot.Constants.RobotConstants.CAN.TalonFX.CORAL_ROLLER_MOTOR_ID;
 import static frc.robot.Constants.RobotConstants.DigitalIO.CORAL_ROLLER_BEAM_BREAK;
 import static frc.robot.Constants.RobotConstants.MAX_BATTERY_VOLTAGE;
+import static frc.robot.parameters.MotorParameters.KrakenX60;
 import static frc.robot.util.MotorDirection.CLOCKWISE_POSITIVE;
 import static frc.robot.util.MotorIdleMode.BRAKE;
 
@@ -63,7 +64,7 @@ public class CoralRoller extends SubsystemBase implements ActiveSubsystem, Shuff
   private static final double MAX_VELOCITY =
       (MotorParameters.KrakenX60.getFreeSpeedRPM() * METERS_PER_REVOLUTION) / 60;
 
-  private static final double KS = 0.0656;
+  private static final double KS = KrakenX60.getKs();
   private static final double KV = (MAX_BATTERY_VOLTAGE - KS) / MAX_VELOCITY;
 
   private static final double ERROR_TIME = 3.0;

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -9,6 +9,7 @@ package frc.robot.subsystems;
 
 import static frc.robot.Constants.RobotConstants.MAX_BATTERY_VOLTAGE;
 import static frc.robot.Constants.RobotConstants.PERIODIC_INTERVAL;
+import static frc.robot.parameters.MotorParameters.KrakenX60;
 
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.nrg948.preferences.RobotPreferences;
@@ -88,13 +89,8 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
       ExponentialProfile.Constraints.fromCharacteristics(
           MAX_BATTERY_VOLTAGE, MAX_SPEED / 2, MAX_ACCELERATION / 64);
 
-  /**
-   * Feedforward constants. The KS is calculated from the internal resistance * free speed current.
-   * We can calculate the internal resistance of the motor with battery voltage / stall current. R =
-   * 12V / 366A, KS = R * 2A for the KrakenX60.
-   */
-  private static final double KS = 0.0656;
-
+  // Feedforward constants
+  private static final double KS = KrakenX60.getKs();
   private static final double KV = (MAX_BATTERY_VOLTAGE - KS) / MAX_SPEED;
   private static final double KA = (MAX_BATTERY_VOLTAGE - KS) / MAX_ACCELERATION;
   private static final double KG = 9.81 * KA;


### PR DESCRIPTION
This change also removes the unused `efficiency` scaling factor from the `ArmParameters` implementations.