### PR TITLE
Uses `DriveToPose` to align to reef and adds a strategy selector

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -71,9 +71,10 @@ public final class Constants {
     public static final double PERIODIC_INTERVAL = 0.02;
 
     /**
-     * The y-offset (in the width direction) of the coral end effector from the center of the robot
+     * The y-offset of the coral end effector from the center of the robot in the robot's frame of
+     * reference.
      */
-    public static final double CORAL_OFFSET_Y = Units.inchesToMeters(10.25);
+    public static final double CORAL_ARM_CENTER_Y_OFFSET = -Units.inchesToMeters(10.25);
 
     public static class PWMPort {
       public static final int LED = 1;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,9 @@ package frc.robot;
 import static frc.robot.commands.AlgaeCommands.removeAlgaeAtLevel;
 import static frc.robot.commands.CoralAndElevatorCommands.raiseElevatorAndTipCoralArm;
 import static frc.robot.commands.CoralCommands.outtakeUntilCoralNotDetected;
+import static frc.robot.commands.DriveCommands.alignToCoralStation;
+import static frc.robot.commands.DriveCommands.alignToReefPosition;
+import static frc.robot.commands.DriveCommands.resetOrientation;
 import static frc.robot.parameters.ElevatorLevel.AlgaeL2;
 import static frc.robot.parameters.ElevatorLevel.AlgaeL3;
 import static frc.robot.parameters.ElevatorLevel.L1;
@@ -38,7 +41,6 @@ import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.AlgaeCommands;
 import frc.robot.commands.ClimberCommands;
 import frc.robot.commands.CoralCommands;
-import frc.robot.commands.DriveCommands;
 import frc.robot.commands.DriveUsingController;
 import frc.robot.commands.ElevatorCommands;
 import frc.robot.commands.FlameCycle;
@@ -160,11 +162,11 @@ public class RobotContainer {
    * joysticks}.
    */
   private void configureBindings() {
-    m_driverController.start().onTrue(DriveCommands.resetOrientation(subsystems));
-    m_driverController.x().whileTrue(DriveCommands.alignToReefPosition(subsystems, LEFT_BRANCH));
-    m_driverController.y().whileTrue(DriveCommands.alignToReefPosition(subsystems, CENTER_REEF));
-    m_driverController.b().whileTrue(DriveCommands.alignToReefPosition(subsystems, RIGHT_BRANCH));
-    m_driverController.a().whileTrue(DriveCommands.alignToCoralStation(subsystems));
+    m_driverController.start().onTrue(resetOrientation(subsystems));
+    m_driverController.x().whileTrue(alignToReefPosition(subsystems, LEFT_BRANCH));
+    m_driverController.y().whileTrue(alignToReefPosition(subsystems, CENTER_REEF));
+    m_driverController.b().whileTrue(alignToReefPosition(subsystems, RIGHT_BRANCH));
+    m_driverController.a().whileTrue(alignToCoralStation(subsystems));
     new Trigger(
             () -> {
               XboxController hid = m_driverController.getHID();

--- a/src/main/java/frc/robot/commands/AlignToReef.java
+++ b/src/main/java/frc/robot/commands/AlignToReef.java
@@ -7,15 +7,10 @@
  
 package frc.robot.commands;
 
-import static frc.robot.Constants.RobotConstants.CORAL_OFFSET_Y;
-import static frc.robot.Constants.RobotConstants.ODOMETRY_CENTER_TO_FRONT_BUMPER_DELTA_X;
+import static frc.robot.util.FieldUtils.getRobotPoseForNearestReefAprilTag;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.Subsystems;
-import frc.robot.util.FieldUtils;
 import frc.robot.util.ReefPosition;
 
 /**
@@ -36,12 +31,8 @@ public class AlignToReef extends AlignToPose {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    // Figure out the robot's desired target pose relative to the nearest reef April Tag.
-    Pose2d currentRobotPose = drivetrain.getPosition();
-    Pose2d nearestTagPose = currentRobotPose.nearest(FieldUtils.getReefAprilTags());
-    double xOffset = ODOMETRY_CENTER_TO_FRONT_BUMPER_DELTA_X;
-    double yOffset = reefPosition.yOffset() - CORAL_OFFSET_Y;
-    targetPose = nearestTagPose.plus(new Transform2d(xOffset, yOffset, Rotation2d.k180deg));
+    // Figure out the robot's target pose.
+    targetPose = getRobotPoseForNearestReefAprilTag(drivetrain.getPosition(), reefPosition);
 
     super.initialize();
   }

--- a/src/main/java/frc/robot/commands/DriveToPose.java
+++ b/src/main/java/frc/robot/commands/DriveToPose.java
@@ -7,56 +7,69 @@
  
 package frc.robot.commands;
 
+import static frc.robot.Constants.RobotConstants.PERIODIC_INTERVAL;
+
 import edu.wpi.first.math.controller.HolonomicDriveController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.util.datalog.DataLog;
-import edu.wpi.first.util.datalog.DoubleLogEntry;
 import edu.wpi.first.util.datalog.StructLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.Swerve;
 import java.util.function.Supplier;
 
 /** A command to drive the robot on a straight line in using trapezoidal motion profiling. */
-public class DriveStraight extends Command {
+public class DriveToPose extends Command {
   private final Swerve drivetrain;
   private final HolonomicDriveController controller;
   private final Supplier<Translation2d> translationSupplier;
-  private final double maxSpeed;
   private final Supplier<Rotation2d> orientationSupplier;
-  private final Timer timer = new Timer();
+  private final TrapezoidProfile profile;
+
   private Pose2d initialPose;
-  private Rotation2d heading;
-  private Rotation2d orientation;
-  private TrapezoidProfile profile;
-  private TrapezoidProfile.State initialState;
-  private TrapezoidProfile.State goalState;
+  private Pose2d targetPose;
 
   private static final DataLog LOG = DataLogManager.getLog();
 
-  private final DoubleLogEntry logOrientation =
-      new DoubleLogEntry(LOG, "DriveStraight/orientation");
-  private final DoubleLogEntry logDistance = new DoubleLogEntry(LOG, "DriveStraight/distance");
-  private final DoubleLogEntry logHeading = new DoubleLogEntry(LOG, "DriveStraight/heading");
   private final StructLogEntry<Pose2d> logInitialPose =
-      StructLogEntry.create(LOG, "DriveStraight/initialPose", Pose2d.struct);
-  private final StructLogEntry<Pose2d> logFinalPose =
-      StructLogEntry.create(LOG, "DriveStraight/finalPose", Pose2d.struct);
+      StructLogEntry.create(LOG, "command/initialPose", Pose2d.struct);
+  private final StructLogEntry<Pose2d> logTargetPose =
+      StructLogEntry.create(LOG, "command/targetPose", Pose2d.struct);
+  private final StructLogEntry<Pose2d> logTrajectoryPose =
+      StructLogEntry.create(LOG, "command/trajectoryPose", Pose2d.struct);
+  private final StructLogEntry<Pose2d> logNextPose =
+      StructLogEntry.create(LOG, "command/nextPose", Pose2d.struct);
 
   /**
-   * Creates a new DriveStraight that drives robot along the specified vector at maximum speed while
+   * Creates a new command that drives robot the specified distance in the direction of its current
+   * orientation.
+   *
+   * @param drivetrain The {@link Swerve} representing the robot drivetrain.
+   * @param distance The distance to travel in meters.
+   * @param maxSpeed The maximum speed at which to travel.
+   */
+  public DriveToPose(Swerve drivetrain, double distance, double maxSpeed) {
+    this(
+        drivetrain,
+        () -> new Translation2d(distance, drivetrain.getOrientation()),
+        maxSpeed,
+        () -> drivetrain.getOrientation());
+  }
+
+  /**
+   * Creates a new command that drives robot along the specified vector at maximum speed while
    * maintaining the current orientation of the robot.
    *
    * @param drivetrain The {@link Swerve} representing the robot drivetrain.
    * @param translation A {@link Translation2d} instance describing the line on which to travel.
    *     This is a vector relative to the current position.
    */
-  public DriveStraight(Swerve drivetrain, Translation2d translation) {
+  public DriveToPose(Swerve drivetrain, Translation2d translation) {
     this(
         drivetrain,
         () -> translation,
@@ -65,21 +78,21 @@ public class DriveStraight extends Command {
   }
 
   /**
-   * Creates a new DriveStraight that drives robot along the specified vector and speed while
-   * maintaining the current orientation of the robot.
+   * Creates a new command that drives robot along the specified vector and speed while maintaining
+   * the current orientation of the robot.
    *
    * @param drivetrain The {@link Swerve} representing the robot drivetrain.
    * @param translation A {@link Translation2d} instance describing the line on which to travel.
    *     This is a vector relative to the current position.
    * @param maxSpeed The maximum speed at which to travel.
    */
-  public DriveStraight(Swerve drivetrain, Translation2d translation, double maxSpeed) {
+  public DriveToPose(Swerve drivetrain, Translation2d translation, double maxSpeed) {
     this(drivetrain, () -> translation, maxSpeed, () -> drivetrain.getPosition().getRotation());
   }
 
   /**
-   * Creates a new DriveStraight that drives robot along the specified vector while rotating the
-   * robot to the desired orientation.
+   * Creates a new command that drives robot along the specified vector while rotating the robot to
+   * the desired orientation.
    *
    * @param drivetrain The {@link Swerve} representing the robot drivetrain.
    * @param translation A {@link Translation2d} instance describing the line on which to travel.
@@ -87,21 +100,21 @@ public class DriveStraight extends Command {
    * @param maxSpeed The maximum speed at which to travel.
    * @param orientation The desired orientation at the end of the command.
    */
-  public DriveStraight(
+  public DriveToPose(
       Swerve drivetrain, Translation2d translation, double maxSpeed, Rotation2d orientation) {
     this(drivetrain, () -> translation, maxSpeed, () -> orientation);
   }
 
   /**
-   * Creates a new DriveStraight that drives robot to the specified absolute location and
-   * orientation on the field.
+   * Creates a new command that drives robot to the specified absolute location and orientation on
+   * the field.
    *
    * @param drivetrain The {@link Swerve} representing the robot drivetrain.
    * @param position A {@link Pose2d} instance describing the absolute position and orientation to
    *     drive to.
    * @param maxSpeed The maximum speed at which to travel.
    */
-  public DriveStraight(Swerve drivetrain, Pose2d position, double maxSpeed) {
+  public DriveToPose(Swerve drivetrain, Pose2d position, double maxSpeed) {
     this(
         drivetrain,
         () -> position.getTranslation().minus(drivetrain.getPosition().getTranslation()),
@@ -109,13 +122,9 @@ public class DriveStraight extends Command {
         () -> position.getRotation());
   }
 
-  public DriveStraight(Swerve drivetrain, double distance, double maxSpeed) {
-    this(drivetrain, new Translation2d(distance, 0), maxSpeed, drivetrain.getOrientation());
-  }
-
   /**
-   * Creates a new DriveStraight that drives robot to the specified absolute location and
-   * orientation on the field.
+   * Creates a new command that drives robot to the specified absolute location and orientation on
+   * the field.
    *
    * @param drivetrain The {@link Swerve} representing the robot drivetrain.
    * @param translationSupplier Supplies a {@link Translation2d} instance describing the line on
@@ -123,7 +132,7 @@ public class DriveStraight extends Command {
    * @param maxSpeed The maximum speed at which to travel.
    * @param orientationSupplier Supplies the desired orientation at the end of the command.
    */
-  private DriveStraight(
+  private DriveToPose(
       Swerve drivetrain,
       Supplier<Translation2d> translationSupplier,
       double maxSpeed,
@@ -131,7 +140,9 @@ public class DriveStraight extends Command {
     this.drivetrain = drivetrain;
     this.translationSupplier = translationSupplier;
     this.controller = drivetrain.createDriveController();
-    this.maxSpeed = maxSpeed;
+    this.profile =
+        new TrapezoidProfile(
+            new TrapezoidProfile.Constraints(maxSpeed, Swerve.getMaxAcceleration() * 0.3));
     this.orientationSupplier = orientationSupplier;
 
     addRequirements(drivetrain);
@@ -141,52 +152,59 @@ public class DriveStraight extends Command {
   public void initialize() {
     initialPose = drivetrain.getPosition();
     Translation2d translation = translationSupplier.get();
-    double distance = translation.getNorm();
-    heading = translation.getAngle();
-    orientation = orientationSupplier.get();
-    profile =
-        new TrapezoidProfile(
-            new TrapezoidProfile.Constraints(maxSpeed, Swerve.getMaxAcceleration() * 0.3));
+    Rotation2d orientation = orientationSupplier.get();
 
-    initialState = new TrapezoidProfile.State(0, 0);
-    goalState = new TrapezoidProfile.State(distance, 0);
+    targetPose = initialPose.plus(new Transform2d(translation, orientation));
 
-    timer.reset();
-    timer.start();
-
-    logOrientation.append(orientation.getDegrees());
-    logDistance.append(distance);
-    logHeading.append(heading.getDegrees());
     logInitialPose.append(initialPose);
+    logTargetPose.append(targetPose);
   }
 
   @Override
   public void execute() {
-    // Calculate the next state (position and velocity) of motion using the
+    var currentPose = drivetrain.getPosition();
+    var currentSpeeds = drivetrain.getChassisSpeeds();
+    var delta = targetPose.getTranslation().minus(currentPose.getTranslation());
+    double distanceToGo = delta.getNorm();
+    Rotation2d heading = delta.getAngle();
+
+    // Calculate the next setpoint of motion (position and velocity) using the
     // trapezoidal profile.
-    TrapezoidProfile.State state = profile.calculate(timer.get(), initialState, goalState);
+    double speed = Math.hypot(currentSpeeds.vxMetersPerSecond, currentSpeeds.vyMetersPerSecond);
+    var currentState = new TrapezoidProfile.State(0, speed);
+    var goalState = new TrapezoidProfile.State(distanceToGo, 0);
+    var setpoint = profile.calculate(PERIODIC_INTERVAL, currentState, goalState);
 
     // Determine the next position on the field by offsetting the initial position
     // by the distance moved along the line of travel.
-    Translation2d offset = new Translation2d(state.position, heading);
-    Pose2d nextPose = new Pose2d(initialPose.getTranslation().plus(offset), heading);
+    Translation2d offset = new Translation2d(setpoint.position, heading);
+    Pose2d trajectoryPose = new Pose2d(currentPose.getTranslation().plus(offset), heading);
 
     // Calculate the swerve drive module states needed to reach the next state.
     ChassisSpeeds speeds =
-        controller.calculate(drivetrain.getPosition(), nextPose, state.velocity, orientation);
+        controller.calculate(
+            drivetrain.getPosition(), trajectoryPose, setpoint.velocity, targetPose.getRotation());
 
     drivetrain.setChassisSpeeds(speeds);
+
+    var nextPose =
+        new Pose2d(
+            trajectoryPose.getTranslation(),
+            currentPose
+                .getRotation()
+                .plus(new Rotation2d(speeds.omegaRadiansPerSecond * PERIODIC_INTERVAL)));
+
+    logTrajectoryPose.append(trajectoryPose);
+    logNextPose.append(nextPose);
   }
 
   @Override
   public boolean isFinished() {
-    return profile.isFinished(timer.get());
+    return profile.isFinished(0);
   }
 
   @Override
   public void end(boolean interrupted) {
     drivetrain.stopMotors();
-    timer.stop();
-    logFinalPose.append(drivetrain.getPosition());
   }
 }

--- a/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeGrabber.java
@@ -39,24 +39,24 @@ import frc.robot.util.TalonFXAdapter;
 
 @RobotPreferencesLayout(
     groupName = "AlgaeGrabber",
-    row = 1,
-    column = 1,
-    width = 3,
-    height = 1,
+    row = 0,
+    column = 6,
+    width = 1,
+    height = 3,
     type = "Grid Layout",
-    gridColumns = 3,
-    gridRows = 0)
+    gridColumns = 1,
+    gridRows = 3)
 public class AlgaeGrabber extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
 
   @RobotPreferencesValue(column = 0, row = 0)
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("AlgaeGrabber", "Enable Tab", false);
 
-  @RobotPreferencesValue(column = 1, row = 0)
+  @RobotPreferencesValue(column = 0, row = 1)
   public static final RobotPreferences.DoubleValue INTAKE_VELOCITY =
       new RobotPreferences.DoubleValue("AlgaeGrabber", "Intake Velocity", 1);
 
-  @RobotPreferencesValue(column = 2, row = 0)
+  @RobotPreferencesValue(column = 0, row = 1)
   public static final RobotPreferences.DoubleValue OUTTAKE_VELOCITY =
       new RobotPreferences.DoubleValue("AlgaeGrabber", "Outtake Velocity", 2);
 

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -48,7 +48,7 @@ import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
 import java.util.Set;
 
-@RobotPreferencesLayout(groupName = "Elevator", row = 0, column = 5, width = 2, height = 3)
+@RobotPreferencesLayout(groupName = "Elevator", row = 0, column = 5, width = 1, height = 3)
 public class Elevator extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
 
   private static final DataLog LOG = DataLogManager.getLog();

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -49,7 +49,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.commands.DriveStraight;
+import frc.robot.commands.DriveToPose;
 import frc.robot.drive.SwerveDrive;
 import frc.robot.drive.SwerveModule;
 import frc.robot.parameters.SwerveAngleEncoder;
@@ -92,6 +92,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
   public static RobotPreferences.BooleanValue ENABLE_RUMBLE =
       new RobotPreferences.BooleanValue("Drive", "Enable Rumble", true);
 
+  public static final double ROTATIONAL_KP = 1.0;
   public static final double DRIVE_KP = 1.0;
 
   // 4 pairs of motors for drive & steering.
@@ -361,7 +362,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    */
   public HolonomicDriveController createDriveController() {
     ProfiledPIDController thetaController =
-        new ProfiledPIDController(1.0, 0.0, 0.0, getRotationalConstraints());
+        new ProfiledPIDController(ROTATIONAL_KP, 0.0, 0.0, getRotationalConstraints());
 
     thetaController.enableContinuousInput(-Math.PI, Math.PI);
 
@@ -595,7 +596,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
       GenericEntry distance = driveStraight.add("Distance", 0).getEntry();
       driveStraight.add(
           Commands.defer(
-                  () -> new DriveStraight(this, distance.getDouble(0), Swerve.getMaxSpeed() * 0.25),
+                  () -> new DriveToPose(this, distance.getDouble(0), Swerve.getMaxSpeed() * 0.25),
                   Set.of(this))
               .withName("Drive Straight"));
     }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -74,7 +74,7 @@ import java.util.function.Supplier;
     height = 1,
     type = "Grid Layout",
     gridColumns = 3,
-    gridRows = 1)
+    gridRows = 2)
 public class Swerve extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
   private static final DataLog LOG = DataLogManager.getLog();
   private static final Rotation2d ROTATE_180_DEGREES = Rotation2d.fromDegrees(180);

--- a/src/main/java/frc/robot/util/FieldUtils.java
+++ b/src/main/java/frc/robot/util/FieldUtils.java
@@ -89,4 +89,19 @@ public final class FieldUtils {
   public static ArrayList<Pose2d> getCoralStationAprilTags() {
     return isRedAlliance() ? redCoralStationTags : blueCoralStationTags;
   }
+
+  /**
+   * Returns the {@link Pose2d} describing the robot's expected pose at the specified position of
+   * the nearest reef side.
+   *
+   * @param currentRobotPose The swerve drivetrain.
+   * @param reefPosition The target reef position.
+   * @return The {@link Pose2d} of the nearest reef AprilTag to the robot's current position.
+   */
+  public static Pose2d getRobotPoseForNearestReefAprilTag(
+      Pose2d currentRobotPose, ReefPosition reefPosition) {
+    Pose2d nearestTagPose = currentRobotPose.nearest(getReefAprilTags());
+
+    return nearestTagPose.plus(reefPosition.tagToRobot());
+  }
 }

--- a/src/main/java/frc/robot/util/ReefPosition.java
+++ b/src/main/java/frc/robot/util/ReefPosition.java
@@ -7,26 +7,52 @@
  
 package frc.robot.util;
 
+import static frc.robot.Constants.RobotConstants.CORAL_ARM_CENTER_Y_OFFSET;
+import static frc.robot.Constants.RobotConstants.ODOMETRY_CENTER_TO_FRONT_BUMPER_DELTA_X;
 import static frc.robot.Constants.VisionConstants.BRANCH_TO_REEF_APRILTAG;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 
 /**
  * An enum that represents the reef alignment positions as viewed face on.
  *
- * @param yOffset The y offset of the reef position from the center reef position directly above the
- *     center of the AprilTag.
+ * @param yOffset The y offset from the center of the AprilTag to the reef position in the
+ *     AprilTag's frame of reference.
  */
 public enum ReefPosition {
   LEFT_BRANCH(-BRANCH_TO_REEF_APRILTAG),
   CENTER_REEF(0.0),
   RIGHT_BRANCH(BRANCH_TO_REEF_APRILTAG);
 
-  private double yOffset;
+  private final double yOffset;
+  private final Transform2d tagToRobot;
 
   ReefPosition(double yOffset) {
     this.yOffset = yOffset;
+    this.tagToRobot =
+        new Transform2d(
+            ODOMETRY_CENTER_TO_FRONT_BUMPER_DELTA_X,
+            CORAL_ARM_CENTER_Y_OFFSET + yOffset,
+            Rotation2d.k180deg);
   }
 
+  /**
+   * Returns the y offset from the center of the AprilTag to the reef position in the AprilTag's
+   * frame of reference.
+   *
+   * @return The y offset.
+   */
   public double yOffset() {
     return yOffset;
+  }
+
+  /**
+   * Returns the transform from the AprilTag to the robot's center of rotation.
+   *
+   * @return The transform from the AprilTag to the robot's center of rotation.
+   */
+  public Transform2d tagToRobot() {
+    return tagToRobot;
   }
 }


### PR DESCRIPTION
This change introduces a new strategy for aligning to the reef using `DriveToPose` and adds a preferences selector to choose among various stratgies to facilitate testing.

This change replaces `DriveStraight` with `DriveToPose` which attempts to better correct from position error.