### PR TITLE
Unifies selection of robot-specific subsystem parameters

### DIFF
--- a/src/main/java/frc/robot/RobotAutonomous.java
+++ b/src/main/java/frc/robot/RobotAutonomous.java
@@ -33,7 +33,7 @@ import java.util.function.DoubleSupplier;
 public class RobotAutonomous {
   private final SendableChooser<Command> chooser;
 
-  private final RobotConfig config = Swerve.PARAMETERS.getValue().getPathplannerConfig();
+  private final RobotConfig config = Swerve.PARAMETERS.getPathplannerConfig();
 
   public RobotAutonomous(Subsystems subsystems, DoubleSupplier rotationFeedbackOverride) {
     AutoBuilder.configure(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,10 +53,6 @@ import frc.robot.commands.ElevatorCommands;
 import frc.robot.commands.LEDCommands;
 import frc.robot.commands.ManipulatorCommands;
 import frc.robot.parameters.Colors;
-import frc.robot.subsystems.AprilTag;
-import frc.robot.subsystems.AprilTag.VisionParameters;
-import frc.robot.subsystems.Climber;
-import frc.robot.subsystems.Climber.ClimberParameters;
 import frc.robot.subsystems.Subsystems;
 import frc.robot.util.MotorIdleMode;
 
@@ -66,7 +62,7 @@ import frc.robot.util.MotorIdleMode;
  * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
  * subsystems, commands, and trigger mappings) should be declared here.
  */
-@RobotPreferencesLayout(groupName = "Preferences", column = 0, row = 0, width = 1, height = 2)
+@RobotPreferencesLayout(groupName = "Preferences", column = 0, row = 0, width = 2, height = 2)
 public class RobotContainer {
   private static final int COAST_MODE_DELAY = 10;
 
@@ -86,28 +82,12 @@ public class RobotContainer {
   private final StringLogEntry phaseLogger = new StringLogEntry(LOG, "/Robot/Phase");
 
   public enum RobotSelector {
-    PracticeRobot2025(AprilTag.PRACTICE_VISION_PARAMS, Climber.PRACTICE_BOT_PARAMETERS),
-    CompetitionRobot2025(AprilTag.COMPETITION_VISION_PARAMS, Climber.COMPETITION_BOT_PARAMETERS);
-
-    private final VisionParameters visionParams;
-    private final ClimberParameters climberParams;
-
-    private RobotSelector(VisionParameters visionParams, ClimberParameters climberParams) {
-      this.visionParams = visionParams;
-      this.climberParams = climberParams;
-    }
-
-    public VisionParameters visionParameters() {
-      return visionParams;
-    }
-
-    public ClimberParameters climberParameters() {
-      return climberParams;
-    }
+    PracticeRobot2025,
+    CompetitionRobot2025;
   }
 
   @RobotPreferencesValue
-  public static EnumValue<RobotSelector> PARAMETERS =
+  public static EnumValue<RobotSelector> ROBOT_TYPE =
       new EnumValue<RobotSelector>("Preferences", "Robot Type", RobotSelector.CompetitionRobot2025);
 
   /** The container for the robot. Contains subsystems, OI devices, and command bindings. */

--- a/src/main/java/frc/robot/commands/AlignToPose.java
+++ b/src/main/java/frc/robot/commands/AlignToPose.java
@@ -27,7 +27,7 @@ import frc.robot.util.FieldUtils;
  * A {@link Command} that autonomous drives and aligns the robot to the specified branch of the
  * nearest reef side.
  */
-@RobotPreferencesLayout(groupName = "AlignToPose", row = 0, column = 4, width = 1, height = 3)
+@RobotPreferencesLayout(groupName = "AlignToPose", row = 0, column = 4, width = 1, height = 2)
 public class AlignToPose extends Command {
   private static final DataLog LOG = DataLogManager.getLog();
   private static final double MAX_TRANSLATIONAL_POWER = 0.30;

--- a/src/main/java/frc/robot/commands/CoralCommands.java
+++ b/src/main/java/frc/robot/commands/CoralCommands.java
@@ -8,8 +8,8 @@
 package frc.robot.commands;
 
 import static frc.robot.parameters.Colors.YELLOW;
-import static frc.robot.subsystems.Arm.CORAL_ARM;
-import static frc.robot.subsystems.Arm.CORAL_GROUND_INTAKE_ARM;
+import static frc.robot.subsystems.Arm.CORAL_ARM_PARAMETERS;
+import static frc.robot.subsystems.Arm.CORAL_GROUND_INTAKE_ARM_PARAMETERS;
 import static frc.robot.subsystems.CoralRoller.INTAKE_VELOCITY;
 
 import edu.wpi.first.wpilibj2.command.Command;
@@ -25,13 +25,13 @@ import java.util.Set;
 /** A namespace for coral command factory methods. */
 public final class CoralCommands {
   public static final double GROUND_INTAKE_INTAKE_ANGLE =
-      CORAL_GROUND_INTAKE_ARM.getValue().getMinAngleRad();
+      CORAL_GROUND_INTAKE_ARM_PARAMETERS.getMinAngleRad();
   public static final double GROUND_INTAKE_STOWED_ANGLE =
-      CORAL_GROUND_INTAKE_ARM.getValue().getMaxAngleRad();
+      CORAL_GROUND_INTAKE_ARM_PARAMETERS.getMaxAngleRad();
 
-  public static final double CORAL_ROLLER_DETECTION_DELAY = CORAL_ARM.getValue().getRollerDelay();
+  public static final double CORAL_ROLLER_DETECTION_DELAY = CORAL_ARM_PARAMETERS.getRollerDelay();
   public static final double CORAL_GRABBER_DETECTION_DELAY =
-      CORAL_GROUND_INTAKE_ARM.getValue().getRollerDelay();
+      CORAL_GROUND_INTAKE_ARM_PARAMETERS.getRollerDelay();
 
   /** The delay for reversing the coral during auto centering. */
   private static final double AUTO_CENTER_BACKWARDS_SECONDS = 0.2;

--- a/src/main/java/frc/robot/commands/CoralRollerWithController.java
+++ b/src/main/java/frc/robot/commands/CoralRollerWithController.java
@@ -17,7 +17,7 @@ import frc.robot.subsystems.Subsystems;
 
 /* You should consider using the more terse Command factories API instead https://docs.wpilib.org/en/stable/docs/software/commandbased/organizing-command-based.html#defining-commands */
 public class CoralRollerWithController extends Command {
-  @RobotPreferencesValue
+  @RobotPreferencesValue(column = 0, row = 1)
   public static final RobotPreferences.DoubleValue DEADBAND =
       new RobotPreferences.DoubleValue("CoralRoller", "Deadband", 0.1);
 

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -150,7 +150,7 @@ public final class DriveCommands {
     System.out.println("TARGET pose: " + targetPose);
     System.out.println("Target Branch: " + reefPosition);
 
-    SwerveDriveParameters currentSwerveParameters = Swerve.PARAMETERS.getValue();
+    SwerveDriveParameters currentSwerveParameters = Swerve.PARAMETERS;
 
     return AutoBuilder.pathfindToPose(
             targetPose,

--- a/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
@@ -9,7 +9,6 @@ package frc.robot.parameters;
 
 import static frc.robot.Constants.RobotConstants.COMPETITION_ROBOT_MASS_KG;
 import static frc.robot.Constants.RobotConstants.PRACTICE_ROBOT_MASS_KG;
-import static frc.robot.parameters.MotorParameters.Falcon500;
 import static frc.robot.parameters.MotorParameters.KrakenX60;
 import static frc.robot.parameters.MotorParameters.NeoV1_1;
 import static frc.robot.parameters.SwerveModuleParameters.MK4I_L2_PLUS;
@@ -35,19 +34,6 @@ import frc.robot.util.Pigeon2Gyro;
 
 /** An enum representing the properties for the swerve drive base of a specific robot instance. */
 public enum SwerveDriveParameters {
-  CompetitionBase2024(
-      58.5,
-      Units.inchesToMeters(22.755), // .578m  (22.755)
-      Units.inchesToMeters(20.59), // .523m (20.59)
-      MK4I_L2_PLUS,
-      Falcon500,
-      NeoV1_1,
-      // for 2025 testing, the camera is treated as the front of the robot
-      new int[] {13, 14, 8, 9, 19, 18, 6, 7}, // drive, steer motor controller CAN IDs
-      new int[] {34, 33, 32, 31}, // CANCoder CAN IDs
-      new double[] {22.85, 300.85, 324.67, 349.10},
-      false,
-      0),
   PracticeBase2025(
       PRACTICE_ROBOT_MASS_KG,
       Units.inchesToMeters(23.5),

--- a/src/main/java/frc/robot/subsystems/AprilTag.java
+++ b/src/main/java/frc/robot/subsystems/AprilTag.java
@@ -7,6 +7,8 @@
  
 package frc.robot.subsystems;
 
+import static frc.robot.RobotContainer.RobotSelector.CompetitionRobot2025;
+import static frc.robot.RobotContainer.RobotSelector.PracticeRobot2025;
 import static java.lang.Math.toRadians;
 
 import com.nrg948.preferences.RobotPreferences;
@@ -38,6 +40,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.RobotContainer;
 import frc.robot.util.FieldUtils;
 import java.util.List;
 import java.util.Map;
@@ -51,12 +54,12 @@ import org.photonvision.targeting.PhotonTrackedTarget;
 
 @RobotPreferencesLayout(
     groupName = "AprilTag",
-    column = 1,
-    row = 2,
-    width = 3,
-    height = 2,
+    column = 2,
+    row = 3,
+    width = 6,
+    height = 1,
     type = "Grid Layout",
-    gridColumns = 2,
+    gridColumns = 4,
     gridRows = 1)
 public class AprilTag extends SubsystemBase implements ShuffleboardProducer {
 
@@ -100,6 +103,14 @@ public class AprilTag extends SubsystemBase implements ShuffleboardProducer {
           // Optional.of(COMPETITION_ROBOT_TO_BACK_CAMERA));
           Optional.empty());
 
+  public static final VisionParameters PARAMETERS =
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025, PRACTICE_VISION_PARAMS,
+                  CompetitionRobot2025, COMPETITION_VISION_PARAMS))
+          .orElse(COMPETITION_VISION_PARAMS);
+
   @RobotPreferencesValue(column = 0, row = 0)
   public static final RobotPreferences.BooleanValue ENABLED =
       new RobotPreferences.BooleanValue("AprilTag", "Enabled", true);
@@ -129,7 +140,7 @@ public class AprilTag extends SubsystemBase implements ShuffleboardProducer {
     }
   }
 
-  @RobotPreferencesValue(column = 0, row = 1)
+  @RobotPreferencesValue(column = 2, row = 0)
   public static EnumValue<PoseEstimationStrategy> POSE_ESTIMATION_STRATEGY =
       new EnumValue<PoseEstimationStrategy>(
           "AprilTag", "Pose Est. Strategy", PoseEstimationStrategy.MultiTagPnpOnCoprocessor);

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -7,6 +7,9 @@
  
 package frc.robot.subsystems;
 
+import static frc.robot.RobotContainer.RobotSelector.CompetitionRobot2025;
+import static frc.robot.RobotContainer.RobotSelector.PracticeRobot2025;
+
 import com.ctre.phoenix6.configs.FeedbackConfigs;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
@@ -34,23 +37,17 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.RobotContainer;
 import frc.robot.parameters.ArmParameters;
 import frc.robot.parameters.CoralArmParameters;
 import frc.robot.parameters.CoralGroundIntakeArmParameters;
 import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
+import java.util.Map;
 import java.util.function.BooleanSupplier;
 
-@RobotPreferencesLayout(
-    groupName = "Arm",
-    row = 3,
-    column = 4,
-    width = 4,
-    height = 1,
-    type = "Grid Layout",
-    gridColumns = 4,
-    gridRows = 1)
+@RobotPreferencesLayout(groupName = "Arm", row = 2, column = 4, width = 1, height = 1)
 public class Arm extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
   private static final double TOLERANCE = Math.toRadians(1.5);
   private static final double RADIANS_PER_ROTATION = 2 * Math.PI;
@@ -61,20 +58,23 @@ public class Arm extends SubsystemBase implements ActiveSubsystem, ShuffleboardP
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("Arm", "Enable Tab", false);
 
-  @RobotPreferencesValue(row = 0, column = 1, width = 1, height = 1)
-  public static final RobotPreferences.EnumValue<CoralArmParameters> CORAL_ARM =
-      new RobotPreferences.EnumValue<CoralArmParameters>(
-          "Arm", "Coral Arm", CoralArmParameters.CompetitionBase2025);
+  public static final CoralArmParameters CORAL_ARM_PARAMETERS =
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025, CoralArmParameters.PracticeBase2025,
+                  CompetitionRobot2025, CoralArmParameters.CompetitionBase2025))
+          .orElse(CoralArmParameters.CompetitionBase2025);
 
-  @RobotPreferencesValue(row = 0, column = 2, width = 1, height = 1)
-  public static final RobotPreferences.EnumValue<CoralGroundIntakeArmParameters>
-      CORAL_GROUND_INTAKE_ARM =
-          new RobotPreferences.EnumValue<CoralGroundIntakeArmParameters>(
-              "Arm", "Coral Ground Intake Arm", CoralGroundIntakeArmParameters.CompetitionBase2025);
-
-  @RobotPreferencesValue(row = 0, column = 3, width = 1, height = 1)
-  public static final RobotPreferences.BooleanValue ENABLE_CORAL_GROUND_INTAKE_ARM =
-      new RobotPreferences.BooleanValue("Arm", "Enable Coral Ground Intake Arm", true);
+  public static final CoralGroundIntakeArmParameters CORAL_GROUND_INTAKE_ARM_PARAMETERS =
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025,
+                  CoralGroundIntakeArmParameters.PracticeBase2025,
+                  CompetitionRobot2025,
+                  CoralGroundIntakeArmParameters.CompetitionBase2025))
+          .orElse(CoralGroundIntakeArmParameters.CompetitionBase2025);
 
   private static final DataLog LOG = DataLogManager.getLog();
 

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -10,6 +10,8 @@ package frc.robot.subsystems;
 import static frc.robot.Constants.RobotConstants.CAN.TalonFX.COMPETITION_BOT_CLIMBER_MOTOR_ID;
 import static frc.robot.Constants.RobotConstants.CAN.TalonFX.PRACTICE_BOT_CLIMBER_MOTOR_ID;
 import static frc.robot.Constants.RobotConstants.DigitalIO.CLIMBER_ABSOLUTE_ENCODER;
+import static frc.robot.RobotContainer.RobotSelector.CompetitionRobot2025;
+import static frc.robot.RobotContainer.RobotSelector.PracticeRobot2025;
 import static frc.robot.util.MotorDirection.COUNTER_CLOCKWISE_POSITIVE;
 import static frc.robot.util.MotorIdleMode.BRAKE;
 
@@ -36,8 +38,9 @@ import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.RevThroughboreEncoderAdapter;
 import frc.robot.util.TalonFXAdapter;
+import java.util.Map;
 
-@RobotPreferencesLayout(groupName = "Climber", row = 0, column = 7, width = 1, height = 3)
+@RobotPreferencesLayout(groupName = "Climber", row = 0, column = 6, width = 2, height = 3)
 public class Climber extends SubsystemBase implements ShuffleboardProducer, ActiveSubsystem {
   @RobotPreferencesValue
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
@@ -66,7 +69,12 @@ public class Climber extends SubsystemBase implements ShuffleboardProducer, Acti
   public static final ClimberParameters COMPETITION_BOT_PARAMETERS =
       new ClimberParameters(COMPETITION_BOT_CLIMBER_MOTOR_ID, Math.toRadians(179.74));
   public static final ClimberParameters PARAMETERS =
-      RobotContainer.PARAMETERS.getValue().climberParameters();
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025, PRACTICE_BOT_PARAMETERS,
+                  CompetitionRobot2025, COMPETITION_BOT_PARAMETERS))
+          .orElse(COMPETITION_BOT_PARAMETERS);
 
   @RobotPreferencesValue
   public static DoubleValue CLIMB_MAX_POWER = new DoubleValue("Climber", "Max Power", 0.75);

--- a/src/main/java/frc/robot/subsystems/CoralGroundIntakeGrabber.java
+++ b/src/main/java/frc/robot/subsystems/CoralGroundIntakeGrabber.java
@@ -40,9 +40,9 @@ import frc.robot.util.TalonFXAdapter;
 
 @RobotPreferencesLayout(
     groupName = "CoralGroundIntakeGrabber",
-    row = 1,
-    column = 6,
-    width = 1,
+    row = 2,
+    column = 2,
+    width = 2,
     height = 1,
     type = "Grid Layout",
     gridColumns = 1,
@@ -52,7 +52,7 @@ public class CoralGroundIntakeGrabber extends SubsystemBase
 
   @RobotPreferencesValue(column = 0, row = 0)
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
-      new RobotPreferences.BooleanValue("CoralGroundIntakeGrabber", "Enable Tab", true);
+      new RobotPreferences.BooleanValue("CoralGroundIntakeGrabber", "Enable Tab", false);
 
   private static final DataLog LOG = DataLogManager.getLog();
 

--- a/src/main/java/frc/robot/subsystems/CoralRoller.java
+++ b/src/main/java/frc/robot/subsystems/CoralRoller.java
@@ -46,18 +46,26 @@ import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
 import java.util.Set;
 
-@RobotPreferencesLayout(groupName = "CoralRoller", row = 2, column = 0, width = 1, height = 2)
+@RobotPreferencesLayout(
+    groupName = "CoralRoller",
+    row = 2,
+    column = 0,
+    width = 2,
+    height = 2,
+    type = "Grid Layout",
+    gridColumns = 2,
+    gridRows = 2)
 public class CoralRoller extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
 
-  @RobotPreferencesValue
+  @RobotPreferencesValue(column = 0, row = 0)
   public static final RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("CoralRoller", "Enable Tab", false);
 
-  @RobotPreferencesValue
+  @RobotPreferencesValue(column = 1, row = 0)
   public static final RobotPreferences.DoubleValue INTAKE_VELOCITY =
       new RobotPreferences.DoubleValue("CoralRoller", "Intake Velocity", 1);
 
-  @RobotPreferencesValue
+  @RobotPreferencesValue(column = 1, row = 1)
   public static final RobotPreferences.DoubleValue AUTO_CENTER_VELOCITY =
       new RobotPreferences.DoubleValue("CoralRoller", "Auto Center Velocity", -1);
 

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -9,6 +9,8 @@ package frc.robot.subsystems;
 
 import static frc.robot.Constants.RobotConstants.MAX_BATTERY_VOLTAGE;
 import static frc.robot.Constants.RobotConstants.PERIODIC_INTERVAL;
+import static frc.robot.RobotContainer.RobotSelector.CompetitionRobot2025;
+import static frc.robot.RobotContainer.RobotSelector.PracticeRobot2025;
 import static frc.robot.parameters.MotorParameters.KrakenX60;
 
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -39,12 +41,14 @@ import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.RobotContainer;
 import frc.robot.commands.ElevatorCommands;
 import frc.robot.parameters.ElevatorLevel;
 import frc.robot.parameters.ElevatorParameters;
 import frc.robot.util.MotorIdleMode;
 import frc.robot.util.RelativeEncoder;
 import frc.robot.util.TalonFXAdapter;
+import java.util.Map;
 import java.util.Set;
 
 @RobotPreferencesLayout(groupName = "Elevator", row = 0, column = 5, width = 1, height = 3)
@@ -57,24 +61,27 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
   private static final double POSITION_ERROR_TIME = 2.0; // seconds
 
   @RobotPreferencesValue
-  public static RobotPreferences.EnumValue<ElevatorParameters> PARAMETERS =
-      new RobotPreferences.EnumValue<ElevatorParameters>(
-          "Elevator", "Robot Base", ElevatorParameters.CompetitionBase2025);
-
-  @RobotPreferencesValue
   public static RobotPreferences.BooleanValue ENABLE_TAB =
       new RobotPreferences.BooleanValue("Elevator", "Enable Tab", false);
+
+  public static final ElevatorParameters PARAMETERS =
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025, ElevatorParameters.PracticeBase2025,
+                  CompetitionRobot2025, ElevatorParameters.CompetitionBase2025))
+          .orElse(ElevatorParameters.CompetitionBase2025);
 
   // Physical parameters of the elevator
   public static final double PRACTICE_BOT_GEAR_RATIO = 9.0 / 2;
   public static final double COMPETITION_BOT_GEAR_RATIO = 9.0 / 2;
-  private static final double GEAR_RATIO = PARAMETERS.getValue().getGearRatio();
+  private static final double GEAR_RATIO = PARAMETERS.getGearRatio();
   private static final double SPROCKET_DIAMETER = 0.05; // meters
-  private static final double MASS = PARAMETERS.getValue().getMass(); // kilograms
+  private static final double MASS = PARAMETERS.getMass(); // kilograms
   private static final double METERS_PER_REVOLUTION = (SPROCKET_DIAMETER * Math.PI) / GEAR_RATIO;
 
-  private static final double MAX_HEIGHT = PARAMETERS.getValue().getMaxHeight(); // meters
-  private static final double MIN_HEIGHT = PARAMETERS.getValue().getMinHeight(); // meters
+  private static final double MAX_HEIGHT = PARAMETERS.getMaxHeight(); // meters
+  private static final double MIN_HEIGHT = PARAMETERS.getMinHeight(); // meters
   private static final double DISABLE_HEIGHT = MIN_HEIGHT + 0.01;
   public static final double STOWED_HEIGHT_FOR_PID = (MIN_HEIGHT + DISABLE_HEIGHT) / 2;
 
@@ -110,8 +117,8 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
   private final TalonFXAdapter mainMotor =
       new TalonFXAdapter(
           "/Elevator",
-          new TalonFX(PARAMETERS.getValue().getMotorID(), "rio"),
-          PARAMETERS.getValue().getMotorDirection(),
+          new TalonFX(PARAMETERS.getMotorID(), "rio"),
+          PARAMETERS.getMotorDirection(),
           MotorIdleMode.BRAKE,
           METERS_PER_REVOLUTION);
 
@@ -288,7 +295,7 @@ public class Elevator extends SubsystemBase implements ActiveSubsystem, Shuffleb
 
     if (atLowerLimit
         && goalState.position == STOWED_HEIGHT_FOR_PID
-        && PARAMETERS.getValue().resetEncoderWhenStowed()) {
+        && PARAMETERS.resetEncoderWhenStowed()) {
       if (!resetEncoderTimer.isRunning()) {
         resetEncoderTimer.restart();
       } else if (resetEncoderTimer.hasElapsed(2.0)) {

--- a/src/main/java/frc/robot/subsystems/Subsystems.java
+++ b/src/main/java/frc/robot/subsystems/Subsystems.java
@@ -7,12 +7,14 @@
  
 package frc.robot.subsystems;
 
+import static frc.robot.subsystems.Arm.CORAL_ARM_PARAMETERS;
+import static frc.robot.subsystems.Arm.CORAL_GROUND_INTAKE_ARM_PARAMETERS;
+
 import com.nrg948.preferences.RobotPreferences;
 import edu.wpi.first.util.datalog.StringLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Subsystem;
-import frc.robot.RobotContainer;
 import frc.robot.commands.CoralCommands;
 import frc.robot.parameters.ElevatorLevel;
 import frc.robot.util.MotorIdleMode;
@@ -30,11 +32,11 @@ public class Subsystems {
   public final Elevator elevator = new Elevator();
 
   public final CoralRoller coralRoller = new CoralRoller();
-  public final Arm coralArm = new Arm(Arm.CORAL_ARM.getValue(), coralRoller::hasCoral);
+  public final Arm coralArm = new Arm(CORAL_ARM_PARAMETERS, coralRoller::hasCoral);
 
   public final CoralGroundIntakeGrabber coralIntakeGrabber = new CoralGroundIntakeGrabber();
   public final Arm coralIntakeArm =
-      new Arm(Arm.CORAL_GROUND_INTAKE_ARM.getValue(), coralIntakeGrabber::hasCoral);
+      new Arm(CORAL_GROUND_INTAKE_ARM_PARAMETERS, coralIntakeGrabber::hasCoral);
 
   public final Climber climber = new Climber();
 
@@ -58,11 +60,9 @@ public class Subsystems {
     // Add all non-manipulator subsystems to the `all` list.
     var all = new ArrayList<Subsystem>(Arrays.asList(drivetrain, statusLEDs, climber));
 
-    var visionParams = RobotContainer.PARAMETERS.getValue().visionParameters();
-
     // Add optional subsystems to the appropriate list.
     frontCamera =
-        visionParams
+        AprilTag.PARAMETERS
             .robotToFrontCamera()
             .flatMap(
                 (t) -> newOptionalSubsystem(AprilTag.class, AprilTag.ENABLED, "FrontCamera", t));
@@ -70,7 +70,7 @@ public class Subsystems {
     frontCamera.ifPresent((s) -> all.add(s));
 
     backCamera =
-        visionParams
+        AprilTag.PARAMETERS
             .robotToBackCamera()
             .flatMap(
                 (t) -> newOptionalSubsystem(AprilTag.class, AprilTag.ENABLED, "BackCamera", t));

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -7,6 +7,9 @@
  
 package frc.robot.subsystems;
 
+import static frc.robot.RobotContainer.RobotSelector.CompetitionRobot2025;
+import static frc.robot.RobotContainer.RobotSelector.PracticeRobot2025;
+
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.nrg948.preferences.RobotPreferences;
@@ -49,6 +52,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.RobotContainer;
 import frc.robot.commands.DriveToPose;
 import frc.robot.drive.SwerveDrive;
 import frc.robot.drive.SwerveModule;
@@ -66,65 +70,57 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-@RobotPreferencesLayout(
-    groupName = "Drive",
-    column = 1,
-    row = 0,
-    width = 3,
-    height = 1,
-    type = "Grid Layout",
-    gridColumns = 2,
-    gridRows = 2)
+@RobotPreferencesLayout(groupName = "Drive", column = 2, row = 0, width = 2, height = 2)
 public class Swerve extends SubsystemBase implements ActiveSubsystem, ShuffleboardProducer {
   private static final DataLog LOG = DataLogManager.getLog();
   private static final Rotation2d ROTATE_180_DEGREES = Rotation2d.fromDegrees(180);
 
-  @RobotPreferencesValue(column = 0, row = 0)
-  public static RobotPreferences.EnumValue<SwerveDriveParameters> PARAMETERS =
-      new RobotPreferences.EnumValue<SwerveDriveParameters>(
-          "Drive", "Robot Base", SwerveDriveParameters.CompetitionBase2025);
-
-  @RobotPreferencesValue(column = 1, row = 0)
+  @RobotPreferencesValue
   public static RobotPreferences.BooleanValue ENABLE_DRIVE_TAB =
       new RobotPreferences.BooleanValue("Drive", "Enable Tab", false);
 
-  @RobotPreferencesValue(column = 1, row = 1)
+  @RobotPreferencesValue
   public static RobotPreferences.BooleanValue ENABLE_RUMBLE =
       new RobotPreferences.BooleanValue("Drive", "Enable Rumble", true);
+
+  public static final SwerveDriveParameters PARAMETERS =
+      RobotContainer.ROBOT_TYPE
+          .select(
+              Map.of(
+                  PracticeRobot2025, SwerveDriveParameters.PracticeBase2025,
+                  CompetitionRobot2025, SwerveDriveParameters.CompetitionBase2025))
+          .orElse(SwerveDriveParameters.CompetitionBase2025);
 
   public static final double ROTATIONAL_KP = 1.0;
   public static final double DRIVE_KP = 1.0;
 
   // 4 pairs of motors for drive & steering.
   private final MotorController frontLeftDriveMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.FrontLeftDrive);
+      PARAMETERS.getMotorController(SwerveMotors.FrontLeftDrive);
   private final MotorController frontLeftSteeringMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.FrontLeftSteering);
+      PARAMETERS.getMotorController(SwerveMotors.FrontLeftSteering);
 
   private final MotorController frontRightDriveMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.FrontRightDrive);
+      PARAMETERS.getMotorController(SwerveMotors.FrontRightDrive);
   private final MotorController frontRightSteeringMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.FrontRightSteering);
+      PARAMETERS.getMotorController(SwerveMotors.FrontRightSteering);
 
   private final MotorController backLeftDriveMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.BackLeftDrive);
+      PARAMETERS.getMotorController(SwerveMotors.BackLeftDrive);
   private final MotorController backLeftSteeringMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.BackLeftSteering);
+      PARAMETERS.getMotorController(SwerveMotors.BackLeftSteering);
 
   private final MotorController backRightDriveMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.BackRightDrive);
+      PARAMETERS.getMotorController(SwerveMotors.BackRightDrive);
   private final MotorController backRightSteeringMotor =
-      PARAMETERS.getValue().getMotorController(SwerveMotors.BackRightSteering);
+      PARAMETERS.getMotorController(SwerveMotors.BackRightSteering);
 
   // 4 CANcoders for the steering angle.
-  private final CANcoder frontLeftAngle =
-      PARAMETERS.getValue().getAngleEncoder(SwerveAngleEncoder.FrontLeft);
+  private final CANcoder frontLeftAngle = PARAMETERS.getAngleEncoder(SwerveAngleEncoder.FrontLeft);
   private final CANcoder frontRightAngle =
-      PARAMETERS.getValue().getAngleEncoder(SwerveAngleEncoder.FrontRight);
-  private final CANcoder backLeftAngle =
-      PARAMETERS.getValue().getAngleEncoder(SwerveAngleEncoder.BackLeft);
-  private final CANcoder backRightAngle =
-      PARAMETERS.getValue().getAngleEncoder(SwerveAngleEncoder.BackRight);
+      PARAMETERS.getAngleEncoder(SwerveAngleEncoder.FrontRight);
+  private final CANcoder backLeftAngle = PARAMETERS.getAngleEncoder(SwerveAngleEncoder.BackLeft);
+  private final CANcoder backRightAngle = PARAMETERS.getAngleEncoder(SwerveAngleEncoder.BackRight);
 
   private final SwerveModule frontLeftModule =
       createSwerveModule(frontLeftDriveMotor, frontLeftSteeringMotor, frontLeftAngle, "Front Left");
@@ -140,10 +136,10 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
     frontLeftModule, frontRightModule, backLeftModule, backRightModule
   };
 
-  private final Gyro gyro = PARAMETERS.getValue().getGyro();
+  private final Gyro gyro = PARAMETERS.getGyro();
   private final BuiltInAccelerometer accelerometer = new BuiltInAccelerometer();
 
-  private final SwerveDriveKinematics kinematics = PARAMETERS.getValue().getKinematics();
+  private final SwerveDriveKinematics kinematics = PARAMETERS.getKinematics();
 
   private final SwerveDrive drivetrain;
   private final SwerveDrivePoseEstimator odometry;
@@ -180,7 +176,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
     StatusSignal<AngularVelocity> angularVelocity = wheelAngle.getVelocity();
 
     return new SwerveModule(
-        PARAMETERS.getValue(),
+        PARAMETERS,
         driveMotor,
         driveEncoder::getPosition,
         driveEncoder::getVelocity,
@@ -194,7 +190,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
   public Swerve() {
     initializeSensorState();
 
-    drivetrain = new SwerveDrive(PARAMETERS.getValue(), modules, () -> getOrientation());
+    drivetrain = new SwerveDrive(PARAMETERS, modules, () -> getOrientation());
     odometry =
         new SwerveDrivePoseEstimator(
             kinematics, getOrientation(), drivetrain.getModulesPositions(), new Pose2d());
@@ -289,7 +285,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    * @return The maximum drive speed.
    */
   public static double getMaxSpeed() {
-    return PARAMETERS.getValue().getMaxDriveSpeed();
+    return PARAMETERS.getMaxDriveSpeed();
   }
 
   /**
@@ -298,7 +294,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    * @return The maximum drive acceleration.
    */
   public static double getMaxAcceleration() {
-    return PARAMETERS.getValue().getMaxDriveAcceleration();
+    return PARAMETERS.getMaxDriveAcceleration();
   }
 
   /** Gets acceleration in g with an range of +/- 8 g's */
@@ -323,7 +319,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    *     kinematics constraints when following a trajectory.
    */
   public static SwerveDriveKinematicsConstraint getKinematicsConstraint() {
-    return PARAMETERS.getValue().getKinematicsConstraint();
+    return PARAMETERS.getKinematicsConstraint();
   }
 
   /**
@@ -343,7 +339,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    *     constraints on the controller used to reach the goal robot orientation.
    */
   public static TrapezoidProfile.Constraints getRotationalConstraints() {
-    return PARAMETERS.getValue().getRotationalConstraints();
+    return PARAMETERS.getRotationalConstraints();
   }
 
   /**
@@ -352,7 +348,7 @@ public class Swerve extends SubsystemBase implements ActiveSubsystem, Shuffleboa
    * @return The wheel base radius in meters.
    */
   public static double getWheelBaseRadius() {
-    return PARAMETERS.getValue().getWheelBaseRadius();
+    return PARAMETERS.getWheelBaseRadius();
   }
 
   /**

--- a/src/main/java/frc/robot/util/FieldUtils.java
+++ b/src/main/java/frc/robot/util/FieldUtils.java
@@ -27,7 +27,7 @@ public final class FieldUtils {
   private static final int FIRST_RED_CORAL_STATION_APRILTAG_ID = 1;
   private static final int FIRST_BLUE_CORAL_STATION_APRILTAG_ID = 12;
 
-  @RobotPreferencesValue(column = 1, row = 1)
+  @RobotPreferencesValue(column = 3, row = 0)
   public static RobotPreferences.EnumValue<AprilTagFieldParameters> FIELD_LAYOUT_PREFERENCE =
       new RobotPreferences.EnumValue<AprilTagFieldParameters>(
           "AprilTag", "Field Layout", AprilTagFieldParameters.k2025ReefscapeWelded);


### PR DESCRIPTION
This change leverages the new `EnumValue<V>.select()` method added in NRG948/nrgcommon#41 to select subsystem specific parameters using the single "Robot Type" preferences value. It also adjusts the Preferences tab layout for better organization.